### PR TITLE
Feat/18 랜딩 페이지 비디오 섹션 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^2.8.2",
         "axios": "^1.10.0",
+        "gsap": "^3.13.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.60.0",
@@ -3258,6 +3259,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "front",
       "version": "0.0.0",
       "dependencies": {
+        "@gsap/react": "^2.1.2",
         "@reduxjs/toolkit": "^2.8.2",
         "axios": "^1.10.0",
         "gsap": "^3.13.0",
@@ -943,6 +944,16 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@gsap/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==",
+      "license": "SEE LICENSE AT https://gsap.com/standard-license",
+      "peerDependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=17"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.10.0",
+    "gsap": "^3.13.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.60.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.2",
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.10.0",
     "gsap": "^3.13.0",

--- a/src/features/landingPage/FeatureSection.tsx
+++ b/src/features/landingPage/FeatureSection.tsx
@@ -1,0 +1,10 @@
+const FeatureSection = () => {
+  return (
+    <div className="min-h-screen w-full flex justify-center items-center">
+      기능 설명 섹션입니다기능 설명 섹션입니다기능 설명 섹션입니다기능 설명 섹션입니다기능 설명
+      섹션입니다
+    </div>
+  );
+};
+
+export default FeatureSection;

--- a/src/features/landingPage/StartCTASection.tsx
+++ b/src/features/landingPage/StartCTASection.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 const StartCTASection = () => {
   const navigate = useNavigate();
   return (
-    <div className="relative w-full h-screen overflow-hidden flex items-center justify-center max-lg:px-6">
+    <div className="relative w-full h-screen overflow-hidden flex items-center justify-center max-lg:px-6 bg-white">
       <div className="absolute left-[-20px] top-5 max-xl:hidden">
         <img src="/images/landing/CTARabbit.svg" alt="CTA토끼" />
       </div>

--- a/src/features/landingPage/VideoSection.tsx
+++ b/src/features/landingPage/VideoSection.tsx
@@ -1,20 +1,14 @@
-import { useEffect, useRef } from 'react';
+import { useRef, forwardRef, useImperativeHandle } from 'react';
 
 type VideoSectionProps = {
   onVideoEnd: () => void;
-  shouldPlay: boolean;
 };
 
-const VideoSection = ({ onVideoEnd, shouldPlay }: VideoSectionProps) => {
+const VideoSection = forwardRef<HTMLVideoElement, VideoSectionProps>(({ onVideoEnd }, ref) => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  useEffect(() => {
-    if (shouldPlay && videoRef.current) {
-      videoRef.current.play().catch((err) => {
-        console.error('비디오 재생 실패:', err);
-      });
-    }
-  }, [shouldPlay]);
+  // ref를 landingPage로 전달
+  useImperativeHandle(ref, () => videoRef.current as HTMLVideoElement);
 
   return (
     <div className="w-full h-screen overflow-hidden z-40">
@@ -23,12 +17,11 @@ const VideoSection = ({ onVideoEnd, shouldPlay }: VideoSectionProps) => {
         src="/videos/hero-rabbit.mp4"
         muted
         playsInline
-        autoPlay={shouldPlay}
         onEnded={onVideoEnd}
         className="object-cover w-full h-full"
       />
     </div>
   );
-};
+});
 
 export default VideoSection;

--- a/src/features/landingPage/VideoSection.tsx
+++ b/src/features/landingPage/VideoSection.tsx
@@ -23,6 +23,7 @@ const VideoSection = ({ onVideoEnd, shouldPlay }: VideoSectionProps) => {
         src="/videos/hero-rabbit.mp4"
         muted
         playsInline
+        autoPlay={shouldPlay}
         onEnded={onVideoEnd}
         className="object-cover w-full h-full"
       />

--- a/src/features/landingPage/VideoSection.tsx
+++ b/src/features/landingPage/VideoSection.tsx
@@ -1,14 +1,27 @@
+import { useEffect, useRef } from 'react';
+
 type VideoSectionProps = {
   onVideoEnd: () => void;
+  shouldPlay: boolean;
 };
 
-const VideoSection = ({ onVideoEnd }: VideoSectionProps) => {
+const VideoSection = ({ onVideoEnd, shouldPlay }: VideoSectionProps) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (shouldPlay && videoRef.current) {
+      videoRef.current.play().catch((err) => {
+        console.error('비디오 재생 실패:', err);
+      });
+    }
+  }, [shouldPlay]);
+
   return (
-    <div className="w-full h-screen overflow-hidden">
+    <div className="w-full h-screen overflow-hidden z-40">
       <video
+        ref={videoRef}
         src="/videos/hero-rabbit.mp4"
         muted
-        autoPlay
         playsInline
         onEnded={onVideoEnd}
         className="object-cover w-full h-full"

--- a/src/features/landingPage/components/PurpleCircle.tsx
+++ b/src/features/landingPage/components/PurpleCircle.tsx
@@ -1,0 +1,13 @@
+import { forwardRef } from 'react';
+
+const PurpleCircle = forwardRef<HTMLDivElement>((_, ref) => {
+  return (
+    <div
+      ref={ref}
+      className="circle w-[80vw] h-[80vw] rounded-full bg-purple04 fixed top-1/2 left-1/2 
+      -translate-x-1/2 -translate-y-1/2 z-30 pointer-events-none"
+    />
+  );
+});
+
+export default PurpleCircle;

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,11 @@
     'Arial', sans-serif;
 }
 
+html,
+body {
+  overflow-x: hidden;
+}
+
 /*스크롤바 안보이게 */
 .scrollbar-hide {
   scrollbar-width: none;

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -53,7 +53,6 @@ const LandingPage = () => {
         start: '20px top',
         end: '+=1000',
         scrub: 0.5,
-        markers: true,
       },
     });
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -7,6 +7,7 @@ import { useGSAP } from '@gsap/react';
 import StartCTASection from '../features/landingPage/StartCTASection';
 import VideoSection from '../features/landingPage/VideoSection';
 import FeatureSection from '../features/landingPage/FeatureSection';
+import PurpleCircle from '../features/landingPage/components/PurpleCircle';
 
 gsap.registerPlugin(useGSAP, ScrollTrigger, ScrollToPlugin);
 
@@ -128,11 +129,7 @@ const LandingPage = () => {
   return (
     <div className="relative">
       {/* 보라색 원 */}
-      <div
-        ref={circleRef}
-        className="circle w-[80vw] h-[80vw] rounded-full bg-purple04 fixed top-1/2 left-1/2 
-        -translate-x-1/2 -translate-y-1/2 z-30 pointer-events-none"
-      />
+      <PurpleCircle ref={circleRef} />
 
       {/* 비디오 */}
       <div

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { ScrollToPlugin } from 'gsap/ScrollToPlugin';
@@ -20,22 +20,29 @@ const LandingPage = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useGSAP(() => {
-    // 원 초기 세팅
-    gsap.set(circleRef.current, {
-      scale: 0.1,
-      opacity: 1,
+    // 보라색 원 & 영상 중심에 고정
+    const centerFixedStyle = {
       position: 'fixed',
       top: '50%',
       left: '50%',
       xPercent: -50,
       yPercent: -50,
+    };
+
+    // 보라색 원 초기 세팅
+    gsap.set(circleRef.current, {
+      ...centerFixedStyle,
+      scale: 0.1,
+      opacity: 1,
       zIndex: 30,
     });
 
-    // 비디오 마스크 초기 세팅
+    // 영상 마스크 초기 세팅
     gsap.set(videoMaskRef.current, {
-      clipPath: 'circle(5% at 50% 50%)',
+      ...centerFixedStyle,
+      clipPath: 'circle(10% at 50% 50%)',
       opacity: 0,
+      zIndex: 40,
     });
 
     // 애니메이션 순차 실행
@@ -43,16 +50,17 @@ const LandingPage = () => {
       scrollTrigger: {
         trigger: featureSectionRef.current,
         start: '20px top',
-        end: 'bottom top',
+        end: '+=1000',
         scrub: 0.5,
         markers: true,
       },
     });
+
     // 원 & 영상 애니메이션
     tl.to(
       circleRef.current,
       {
-        scale: 20,
+        scale: 30,
         opacity: 1,
         ease: 'power1.out',
         duration: 5,
@@ -73,7 +81,7 @@ const LandingPage = () => {
     ScrollTrigger.create({
       trigger: featureSectionRef.current,
       start: '20px top',
-      end: 'bottom top',
+      end: 'center top',
       pin: true,
 
       onUpdate: (self) => {
@@ -93,15 +101,6 @@ const LandingPage = () => {
         if (self.direction === -1 && !videoEnded && !video.paused) {
           video.pause();
         }
-
-        // CTA 등장 애니메이션
-        if (ctaRef.current) {
-          const visible = progress > 0.95 && videoEnded;
-          gsap.set(ctaRef.current, {
-            opacity: visible ? 1 : 0,
-            pointerEvents: visible ? 'auto' : 'none',
-          });
-        }
       },
 
       // 역방향 스크롤 후 트리거를 떠났을 때
@@ -115,6 +114,16 @@ const LandingPage = () => {
       },
     });
   }, []);
+
+  useEffect(() => {
+    if (videoEnded && ctaRef.current) {
+      gsap.to(ctaRef.current, {
+        opacity: 1,
+        pointerEvents: 'auto',
+        duration: 1,
+      });
+    }
+  }, [videoEnded]);
 
   return (
     <div className="relative">
@@ -131,7 +140,12 @@ const LandingPage = () => {
         className="fixed top-0 left-0 w-screen h-screen z-50 flex items-center justify-center overflow-hidden pointer-events-auto"
         style={{ clipPath: 'circle(5% at 50% 50%)' }}
       >
-        <VideoSection ref={videoRef} onVideoEnd={() => setVideoEnded(true)} />
+        <VideoSection
+          ref={videoRef}
+          onVideoEnd={() => {
+            setVideoEnded(true);
+          }}
+        />
       </div>
 
       {/* 기능 섹션 */}
@@ -141,7 +155,7 @@ const LandingPage = () => {
 
       {/* CTA 섹션 */}
       <div
-        className="fixed top-0 left-0 w-screen h-screen z-50 flex items-center justify-center transition-opacity duration-1000"
+        className="fixed top-0 left-0 w-screen h-screen z-50 flex items-center justify-center transition-opacity duration-500"
         style={{ opacity: videoEnded ? 1 : 0, pointerEvents: videoEnded ? 'auto' : 'none' }}
         ref={ctaRef}
       >


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 애니메이션 적용을 위해 gsap 라이브러리 및 패키지를 설치하였습니다.
2. 가로 스크롤 방지를 위해 index.css에 `overflow-x:hidden`을 추가하였습니다.
3. 보라색 원이 확대되는 애니메이션을 구현하였습니다.
4. `forwardRef`로 랜딩페이지에서 비디오 섹션의 비디오 제어가 가능하도록 하였습니다.
5. 역방향 스크롤 시 영상이 일시정지되고, 다시 스크롤하면 재생되도록 설정하였습니다.
6. 영상 종료 후 역스크롤 → 재진입 시 CTA 섹션이 정상적으로 등장하도록 수정하였습니다.
7. 보라색 원을 컴포넌트로 분리하였습니다.

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- index.css에 overflow-x: hidden을 설정하여 가로 스크롤 이슈를 제거했습니다.
- gsap과 ScrollTrigger, Timeline을 사용하여 보라색 원의 확대 및 비디오 등장 애니메이션을 구현했습니다.
- VideoSection에서 `forwardRef` + `useImperativeHandle`을 적용해 외부에서 `video.play()`, `pause()` 등의 직접 제어가 가능하게 했습니다.
- videoEnded 상태를 기준으로 CTA 섹션의 등장 여부를 결정하도록 하였습니다. 기존에는 영상이 끝난 뒤 다시 스크롤해도 CTA가 등장하지 않는 버그가 있었는데, 이를 `useEffect`와 ScrollTrigger로 제어하여 해결했습니다.

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 화면이 깨지지 않는지 확인해주세요 ✨
- 애니메이션이 잘 적용이 되는지 확인해주세요🐰

## 📷 스크린샷

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
https://github.com/user-attachments/assets/a80c2e41-44ae-4fde-a808-628489208784

## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
