### PR TITLE
토스트 컴포넌트 구현 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,15 @@
 import './App.css';
 import { RouterProvider } from 'react-router-dom';
 import router from './routes';
+import ToastProvider from './components/ToastProvider';
 
 const App = () => {
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <RouterProvider router={router} />
+      <ToastProvider />
+    </>
+  );
 };
 
 export default App;

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,19 @@
+// src/components/common/ToastProvider.tsx
+import React from 'react';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+const ToastProvider: React.FC = () => {
+  return (
+    <ToastContainer
+      position="bottom-center"
+      autoClose={3000}
+      hideProgressBar={true}
+      closeOnClick
+      pauseOnHover
+      draggable
+    />
+  );
+};
+
+export default ToastProvider;

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -1,0 +1,77 @@
+// src/utils/toast.ts
+import { toast, ToastOptions, ToastIcon } from 'react-toastify';
+import { MdCheckCircle, MdError, MdInfo } from 'react-icons/md'; // ✅ React Icons
+
+// ✅ 공통 스타일: flex로 중앙정렬 + gap
+const commonStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '8px 20px', // 세로로 납작
+  borderRadius: '8px', // 둥근 모서리
+  fontSize: '16px', // 텍스트 크기
+  fontWeight: 400,
+  whiteSpace: 'nowrap', // 줄바꿈 안 하고 한 줄로
+  width: 'auto', // 토스트 너비 글자 수에 따라 자동
+  maxWidth: 'none', // 토스트 최대 너비 제한 해제
+};
+
+// ✅ 타입별 스타일
+const toastStyles: Record<'success' | 'error' | 'info', ToastOptions> = {
+  success: {
+    style: {
+      ...commonStyle,
+      backgroundColor: '#28A745', // 초록
+      color: '#ffffff',
+    },
+  },
+  error: {
+    style: {
+      ...commonStyle,
+      backgroundColor: '#DC3545', // 빨강
+      color: '#ffffff',
+    },
+  },
+  info: {
+    style: {
+      ...commonStyle,
+      backgroundColor: '#38383B', // 회색
+      color: '#ffffff',
+    },
+  },
+};
+
+// ✅ 토스트 호출 함수
+export function showToast(
+  message: string,
+  type: 'success' | 'error' | 'info' = 'info',
+  options?: ToastOptions
+) {
+  let icon: ToastIcon = <MdInfo size={20} color="#fff" />;
+
+  if (type === 'success') {
+    icon = <MdCheckCircle size={20} color="#fff" />;
+  }
+  if (type === 'error') {
+    icon = <MdError size={20} color="#fff" />;
+  }
+  if (type === 'info') {
+    icon = <MdInfo size={20} color="#fff" />;
+  }
+
+  toast(message, {
+    position: options?.position || 'top-center',
+    icon: icon,
+    ...toastStyles[type],
+    ...options,
+  });
+}
+
+/*
+사용법:
+import { showToast } from '../utils/toast';
+
+showToast('성공했습니다!', 'success');
+showToast('작업에 실패했습니다.', 'error');
+showToast('안내 메시지입니다.', 'info', { position: 'bottom-right' });
+*/


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 토스트 적용을 위해 ToastProvider를 App.tsx에 추가
2. 토스트 컴포넌트 구현 완료

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 토스트 컴포넌트를 success, error, info 세가지 타입으로 구현했습니다.

## 🕵️‍♀️ 요청사항

- 사용법은 utils > toast.tsx 파일 최하단에 적어놨습니다. 노션/개발위키에도 추가하겠습니다.
- 토스트 멘트와 토스트 위치 지정 가능하며, 색상은 정해진 세가지를 타입에 지정하면 됩니다.
- 토스트 위치의 기본 값은 top-center입니다.

import { showToast } from '../utils/toast';

showToast('성공했습니다!', 'success');
showToast('작업에 실패했습니다.', 'error');
showToast('안내 메시지입니다.', 'info', { position: 'bottom-right' });

## 📷 스크린샷 (선택)
<img width="862" height="313" alt="image" src="https://github.com/user-attachments/assets/42bf2feb-5611-4ed6-8fd7-162a5cdf28b8" />

## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
