### PR TITLE
마이페이지 회원정보 탭 구현 완료

### DIFF
--- a/src/features/myPage/apis/MyInfoApis.ts
+++ b/src/features/myPage/apis/MyInfoApis.ts
@@ -1,0 +1,7 @@
+// src/features/myPage/apis/MyInfoApis.ts
+import axiosInstance from '../../../apis/axiosInstance';
+
+export const getUserInfo = async (userId: number) => {
+  const response = await axiosInstance.get(`/users/${userId}`);
+  return response.data.data; // { id, name, email, phoneNumber, gender, birthday, membershipId, grade }
+};

--- a/src/features/myPage/apis/uplus.ts
+++ b/src/features/myPage/apis/uplus.ts
@@ -1,0 +1,20 @@
+// src/features/myPage/apis/uplus.ts
+import axiosInstance from '../../../apis/axiosInstance';
+
+/**
+ * LG U+ 회원정보를 불러오는 API
+ * @param phone 휴대폰 번호 (01012345678 형식)
+ */
+export async function loadUplusData(phone: string) {
+  try {
+    const response = await axiosInstance.get(`/uplus/user`, {
+      params: {
+        phoneNumber: phone,
+      },
+    });
+    return response; // response.data 에서 code, message, data 접근 가능
+  } catch (error) {
+    console.error('❌ [loadUplusData] API 호출 실패:', error);
+    throw error;
+  }
+}

--- a/src/features/myPage/components/MyInfo/LoginRequiredModal.tsx
+++ b/src/features/myPage/components/MyInfo/LoginRequiredModal.tsx
@@ -1,0 +1,26 @@
+import Modal from '../../../../components/Modal';
+
+interface LoginRequiredModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function LoginRequiredModal({ isOpen, onClose }: LoginRequiredModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="로그인 후 이용해 주세요"
+      message="마이페이지는 로그인 후에만 접근 가능합니다."
+      onClose={onClose}
+      buttons={[
+        {
+          label: '로그인하기',
+          type: 'primary',
+          onClick: () => {
+            window.location.href = '/login';
+          },
+        },
+      ]}
+    />
+  );
+}

--- a/src/features/myPage/components/MyInfo/MembershipInfo.tsx
+++ b/src/features/myPage/components/MyInfo/MembershipInfo.tsx
@@ -1,0 +1,51 @@
+// src/features/myPage/components/MyInfo/MembershipInfo.tsx
+import React from 'react';
+
+type Props = {
+  name: string;
+  grade?: string;
+  onClickLink?: () => void;
+};
+
+const MembershipInfo: React.FC<Props> = ({ name, grade, onClickLink }) => {
+  return (
+    <div className="flex flex-col gap-4">
+      {grade ? (
+        <>
+          <p className="text-black text-title-2 mb-8">
+            안녕하세요 <span className="text-purple04 text-title-2 ">{name.slice(1)}</span>님🐰
+          </p>
+          <p className="text-grey05 text-body-0">
+            {name.slice(1)}님의 멤버십 등급은{' '}
+            <span className="text-purple03 text-body-0-bold">{grade}</span> 입니다.
+            <br /> 놓치기 아까운 혜택이 가득해요!
+          </p>
+          <div className="bg-gradient-myPage text-white text-[96px] font-bold text-center rounded-[18px] px-6 pb-0 pt-4 mt-10">
+            {grade}
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="text-black text-title-2 mb-8">
+            안녕하세요 <span className="text-purple04 text-title-2 ">{name.slice(1)}</span>님🐰
+          </p>
+          <p className="text-grey05 text-body-0">
+            지금은 <span className="text-purple03 text-body-0-bold">멤버십 등급 없이</span> 이용
+            중이에요.
+          </p>
+          <p className="text-grey05 text-body-0">
+            LG U+ 회원이시라면, <br /> 연동 후 고객님의 등급이 자동 적용됩니다.
+          </p>
+          <button
+            onClick={onClickLink}
+            className="bg-purple04 text-white rounded-[10px] px-2 py-3 mt-10 text-body-0-bold hover:bg-purple05"
+          >
+            연동하기
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default MembershipInfo;

--- a/src/features/myPage/components/MyInfo/PasswordChangeModal.tsx
+++ b/src/features/myPage/components/MyInfo/PasswordChangeModal.tsx
@@ -1,0 +1,89 @@
+import Modal from '../../../../components/Modal';
+
+interface PasswordChangeModalProps {
+  isOpen: boolean;
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+  onCurrentChange: (val: string) => void;
+  onNewChange: (val: string) => void;
+  onConfirmChange: (val: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+}
+
+export default function PasswordChangeModal({
+  isOpen,
+  currentPassword,
+  newPassword,
+  confirmPassword,
+  onCurrentChange,
+  onNewChange,
+  onConfirmChange,
+  onCancel,
+  onSubmit,
+}: PasswordChangeModalProps) {
+  const isReady =
+    currentPassword.trim() !== '' && newPassword.trim() !== '' && confirmPassword.trim() !== '';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="비밀번호를 재설정합니다"
+      message="현재 비밀번호와 새 비밀번호를 입력해주세요."
+      onClose={onCancel}
+    >
+      {/* ✅ 이 div 안에 인풋들과 버튼을 모두 넣고 flex-col로 정렬 */}
+      <div className="flex flex-col items-center gap-4 w-full max-w-[436px] mt-4">
+        {/* 인풋 영역 */}
+        <div className="flex flex-col gap-3 w-full">
+          <input
+            type="password"
+            className="w-full h-[50px] px-4 bg-grey01 rounded-[10px] text-body-2 placeholder-grey03"
+            placeholder="현재 비밀번호 입력"
+            value={currentPassword}
+            onChange={(e) => onCurrentChange(e.target.value)}
+          />
+          <input
+            type="password"
+            className="w-full h-[50px] px-4 bg-grey01 rounded-[10px] text-body-2 placeholder-grey03"
+            placeholder="새 비밀번호 입력"
+            value={newPassword}
+            onChange={(e) => onNewChange(e.target.value)}
+          />
+          <input
+            type="password"
+            className="w-full h-[50px] px-4 bg-grey01 rounded-[10px] text-body-2 placeholder-grey03"
+            placeholder="새 비밀번호 확인"
+            value={confirmPassword}
+            onChange={(e) => onConfirmChange(e.target.value)}
+          />
+        </div>
+
+        {/* 버튼 영역 */}
+        <div className="flex gap-4 w-full mt-4">
+          <button
+            onClick={onCancel}
+            className="flex-1 h-[56px] rounded-[10px] border border-grey02 text-grey04 hover:text-grey05"
+          >
+            취소
+          </button>
+          <button
+            onClick={() => {
+              if (!isReady) return;
+              onSubmit();
+            }}
+            disabled={!isReady}
+            className={`flex-1 h-[56px] rounded-[10px] text-title-6 transition duration-200 ${
+              isReady
+                ? 'bg-purple04 text-white hover:bg-purple05'
+                : 'bg-grey01 text-grey03 cursor-not-allowed'
+            }`}
+          >
+            변경하기
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/myPage/components/MyInfo/UplusLinkModal.tsx
+++ b/src/features/myPage/components/MyInfo/UplusLinkModal.tsx
@@ -1,0 +1,54 @@
+// src/features/myPage/components/MyInfo/UplusLinkModal.tsx
+import React from 'react';
+import Modal from '../../../../components/Modal';
+
+interface UplusLinkModalProps {
+  isOpen: boolean;
+  phone: string;
+  onClose: () => void;
+  onVerified: (grade: string) => void;
+  loadUplusData: (phone: string) => Promise<any>; // 실제 API 타입 맞게 수정
+}
+
+const UplusLinkModal: React.FC<UplusLinkModalProps> = ({
+  isOpen,
+  phone,
+  onClose,
+  onVerified,
+  loadUplusData,
+}) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="유플러스 회원이시군요!"
+      message="기존 가입 정보를 불러오시겠습니까?"
+      onClose={onClose}
+      buttons={[
+        {
+          label: '아니요',
+          type: 'secondary',
+          onClick: onClose,
+        },
+        {
+          label: '예',
+          type: 'primary',
+          onClick: async () => {
+            try {
+              const res = await loadUplusData(phone);
+              const { membershipId } = res.data.data;
+              // 여기서 등급을 계산
+              const grade = membershipId ? 'VVIP' : '';
+              onVerified(grade);
+              onClose();
+            } catch (e) {
+              console.error(e);
+              onClose();
+            }
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export default UplusLinkModal;

--- a/src/features/myPage/components/MyInfo/UserDeleteModal.tsx
+++ b/src/features/myPage/components/MyInfo/UserDeleteModal.tsx
@@ -1,0 +1,35 @@
+// src/features/myPage/components/MyInfo/UserDeleteModal.tsx
+import Modal from '../../../../components/Modal';
+
+interface UserDeleteModalProps {
+  isOpen: boolean;
+  password: string;
+  onPasswordChange: (val: string) => void;
+  onCancel: () => void;
+  onDelete: () => void;
+}
+
+export default function UserDeleteModal({
+  isOpen,
+  password,
+  onPasswordChange,
+  onCancel,
+  onDelete,
+}: UserDeleteModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="정말 탈퇴하시겠습니까?"
+      message="탈퇴를 위해 현재 비밀번호를 입력해주세요."
+      input
+      inputPlaceholder="현재 비밀번호 입력"
+      inputValue={password}
+      onInputChange={onPasswordChange}
+      onClose={onCancel}
+      buttons={[
+        { label: '취소', type: 'secondary', onClick: onCancel },
+        { label: '탈퇴하기', type: 'primary', onClick: onDelete },
+      ]}
+    />
+  );
+}

--- a/src/features/myPage/components/MyInfo/UserInfoForm.tsx
+++ b/src/features/myPage/components/MyInfo/UserInfoForm.tsx
@@ -1,0 +1,51 @@
+// src/features/myPage/components/MyInfo/UserInfoForm.tsx
+import React from 'react';
+
+type Props = {
+  name: string;
+  gender: string;
+  birthday: string;
+  phoneNumber: string;
+  email: string;
+};
+
+const UserInfoForm: React.FC<Props> = ({ name, gender, birthday, phoneNumber, email }) => {
+  return (
+    <div className="flex justify-center mt-[100px]">
+      <div className="flex flex-col gap-4 w-[690px]">
+        <InfoRow label="이름" value={name} />
+        <InfoRow label="성별" value={gender === 'MALE' ? '남성' : '여성'} />
+        <InfoRow label="생년월일" value={birthday.replace(/-/g, '.')} />
+        <InfoRow label="휴대폰 번호" value={phoneNumber} />
+        <InfoRow label="이메일" value={email} />
+
+        {/* 비밀번호 row */}
+        <div className="flex items-center">
+          <div className="w-[140px] text-title-4 text-black font-bold">비밀번호</div>
+          <div className="flex-1 flex items-center justify-between bg-grey01 rounded-[18px] px-6 py-4">
+            <span className="tracking-widest select-none">●●●●●●●●</span>
+            <button className="text-purple04 text-body-0">변경하기</button>
+          </div>
+        </div>
+
+        {/* 회원탈퇴 버튼 */}
+        <div className="flex justify-end mt-4">
+          <button className="bg-purple06 hover:bg-grey01 text-white rounded-[18px] px-6 py-3 text-title-5">
+            회원탈퇴
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const InfoRow: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="flex items-center">
+    {/* 왼쪽 라벨 */}
+    <div className="w-[140px] text-title-4 text-black font-bold">{label}</div>
+    {/* 오른쪽 값 박스 */}
+    <div className="flex-1 bg-grey01 rounded-[18px] px-6 py-4 text-body-0 text-grey05">{value}</div>
+  </div>
+);
+
+export default UserInfoForm;

--- a/src/features/myPage/components/MyInfo/UserInfoForm.tsx
+++ b/src/features/myPage/components/MyInfo/UserInfoForm.tsx
@@ -7,9 +7,19 @@ type Props = {
   birthday: string;
   phoneNumber: string;
   email: string;
+  onChangePasswordClick?: () => void;
+  onDeleteClick?: () => void;
 };
 
-const UserInfoForm: React.FC<Props> = ({ name, gender, birthday, phoneNumber, email }) => {
+const UserInfoForm: React.FC<Props> = ({
+  name,
+  gender,
+  birthday,
+  phoneNumber,
+  email,
+  onChangePasswordClick,
+  onDeleteClick,
+}) => {
   return (
     <div className="flex justify-center mt-[100px]">
       <div className="flex flex-col gap-4 w-[690px]">
@@ -24,13 +34,18 @@ const UserInfoForm: React.FC<Props> = ({ name, gender, birthday, phoneNumber, em
           <div className="w-[140px] text-title-4 text-black font-bold">비밀번호</div>
           <div className="flex-1 flex items-center justify-between bg-grey01 rounded-[18px] px-6 py-4">
             <span className="tracking-widest select-none">●●●●●●●●</span>
-            <button className="text-purple04 text-body-0">변경하기</button>
+            <button className="text-purple04 text-body-0" onClick={onChangePasswordClick}>
+              변경하기
+            </button>
           </div>
         </div>
 
         {/* 회원탈퇴 버튼 */}
         <div className="flex justify-end mt-4">
-          <button className="bg-purple06 hover:bg-grey01 text-white rounded-[18px] px-6 py-3 text-title-5">
+          <button
+            className="bg-purple06 hover:bg-purple04 text-white rounded-[18px] px-6 py-3 text-title-5"
+            onClick={onDeleteClick}
+          >
             회원탈퇴
           </button>
         </div>

--- a/src/features/myPage/mock/mockData.ts
+++ b/src/features/myPage/mock/mockData.ts
@@ -238,7 +238,12 @@ export const mockFavorites: FavoriteItem[] = [
 
 // 현재 사용자 목업
 export const mockUser = {
-  userId: 123,
+  userId: 1,
   name: '홍길동',
-  membershipGrade: 'VVIP', // VVIP, VIP, BASIC
+  email: 'hong@example.com',
+  phoneNumber: '010-1234-5678',
+  gender: 'MALE',
+  birthday: '1990-01-01',
+  membershipId: 'M001',
+  grade: 'VIP', // VVIP, VIP, BASIC
 };

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -1,7 +1,26 @@
 import { Outlet } from 'react-router-dom';
 import SideMenu from '../features/myPage/components/SideMenu';
+import { useState } from 'react';
+import LoginRequiredModal from '../features/myPage/components/MyInfo/LoginRequiredModal';
 
 export default function MyPageLayout() {
+  const [isLoggedIn] = useState(true); // 임시로 true값 설정: 실제로는 전역 상태나 context에서 가져오기
+  const [showLoginModal, setShowLoginModal] = useState(true);
+
+  if (!isLoggedIn) {
+    // ✅ 로그인 안된 경우, 뒤쪽 컨텐츠를 전혀 렌더하지 않고 모달만 반환
+    return (
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        onClose={() => {
+          setShowLoginModal(false);
+          // 필요하다면 다른 로직
+        }}
+      />
+    );
+  }
+
+  // ✅ 로그인된 경우에는 마이페이지 레이아웃 정상 렌더
   return (
     <div className="min-h-screen max-h-screen bg-grey01 p-[28px] flex gap-[28px]">
       {/* 좌측 메뉴 */}

--- a/src/pages/myPage/MyInfoPage.tsx
+++ b/src/pages/myPage/MyInfoPage.tsx
@@ -1,25 +1,120 @@
-import MainContentWrapper from '../../features/myPage/components/MainContentWrapper';
-import RightAside from '../../features/myPage/components/RightAside';
+// src/pages/myPage/MyInfoPage.tsx
+import { useEffect, useState } from 'react';
+import MyPageContentLayout from '../../features/myPage/layout/MyPageContentLayout';
+import UserInfoForm from '../../features/myPage/components/MyInfo/UserInfoForm';
+import MembershipInfo from '../../features/myPage/components/MyInfo/MembershipInfo';
 import FadeWrapper from '../../features/myPage/components/FadeWrapper';
+import { mockUser } from '../../features/myPage/mock/mockData';
+import PasswordChangeModal from '../../features/myPage/components/MyInfo/PasswordChangeModal';
+import UserDeleteModal from '../../features/myPage/components/MyInfo/UserDeleteModal';
+import UplusLinkModal from '../../features/myPage/components/MyInfo/UplusLinkModal';
+import { loadUplusData } from '../../features/myPage/apis/uplus';
 
 export default function MyInfoPage() {
-  return (
-    <>
-      <MainContentWrapper>
-        <h1 className="text-xl font-bold mb-4">내 정보</h1>
-        <p>여기에 내 회원 정보가 들어갑니다.</p>
-      </MainContentWrapper>
+  // 실제로는 전역 상태에서 로그인 여부를 가져오면 됨
+  const [user, setUser] = useState<any>(null);
+  const [isPwModalOpen, setIsPwModalOpen] = useState(false);
+  const [currentPw, setCurrentPw] = useState('');
+  const [newPw, setNewPw] = useState('');
+  const [confirmPw, setConfirmPw] = useState('');
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [password, setPassword] = useState('');
+  const [showUplusModal, setShowUplusModal] = useState(false);
+  const [grade, setGrade] = useState<string | undefined>(user?.grade); // 초기 grade
 
-      <RightAside
+  useEffect(() => {
+    // API 미연결로 mockData 사용
+    setUser(mockUser);
+  }, []);
+
+  // 데이터 로딩 중일 때 MainContentWrapper를 유지하면서 로딩 메시지 노출
+  if (!user) {
+    return (
+      <div className="flex flex-row gap-[24px] w-full h-full">
+        <MyPageContentLayout
+          main={<div className="text-center mt-10 text-lg text-gray-500">Loading...</div>}
+          aside={<></>}
+          bottomImage="/images/myPage/bunny-info.webp"
+          bottomImageFallback="/images/myPage/bunny-info.png"
+          bottomImageAlt="회원 정보 토끼"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-row gap-[24px] w-full h-full">
+      <MyPageContentLayout
+        main={
+          <div>
+            <h1 className="text-title-2 text-black mb-8">회원 정보</h1>
+            <UserInfoForm
+              name={user.name}
+              gender={user.gender}
+              birthday={user.birthday}
+              phoneNumber={user.phoneNumber}
+              email={user.email}
+              onChangePasswordClick={() => setIsPwModalOpen(true)}
+              onDeleteClick={() => setDeleteModalOpen(true)}
+            />
+          </div>
+        }
+        aside={
+          <FadeWrapper changeKey={user.grade}>
+            <MembershipInfo
+              name={user.name}
+              grade={grade} //user.grade로 바꾸면 mockData상에서 멤버십등급을 가져와 변경된 UI 보기 가능
+              onClickLink={() => setShowUplusModal(true)}
+            />
+          </FadeWrapper>
+        }
         bottomImage="/images/myPage/bunny-info.webp"
-        bottomImageAlt="회원 정보 토끼"
         bottomImageFallback="/images/myPage/bunny-info.png"
-      >
-        <FadeWrapper changeKey="info">
-          <h1 className="text-xl font-bold mb-4">추가 정보</h1>
-          <p>우측 사이드에 보여줄 내용</p>
-        </FadeWrapper>
-      </RightAside>
-    </>
+        bottomImageAlt="회원 정보 토끼"
+      />
+
+      <UplusLinkModal
+        isOpen={showUplusModal}
+        phone={user.phoneNumber}
+        onClose={() => setShowUplusModal(false)}
+        onVerified={(newGrade) => setGrade(newGrade)}
+        loadUplusData={loadUplusData}
+      />
+
+      <PasswordChangeModal
+        isOpen={isPwModalOpen}
+        currentPassword={currentPw}
+        newPassword={newPw}
+        confirmPassword={confirmPw}
+        onCurrentChange={setCurrentPw}
+        onNewChange={setNewPw}
+        onConfirmChange={setConfirmPw}
+        onCancel={() => {
+          setIsPwModalOpen(false);
+          setCurrentPw('');
+          setNewPw('');
+          setConfirmPw('');
+        }}
+        onSubmit={() => {
+          // 🚨 여기서 비밀번호 변경 API 호출
+          console.log('비밀번호 변경 요청', { currentPw, newPw, confirmPw });
+          setIsPwModalOpen(false);
+          setCurrentPw('');
+          setNewPw('');
+          setConfirmPw('');
+        }}
+      />
+
+      <UserDeleteModal
+        isOpen={deleteModalOpen}
+        password={password}
+        onPasswordChange={setPassword}
+        onCancel={() => setDeleteModalOpen(false)}
+        onDelete={() => {
+          // 🚨 탈퇴 API 호출
+          setDeleteModalOpen(false);
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## 📝 변경 사항

1. 마이페이지 회원정보 조회 api 파일 추가
2. 마이페이지 유플러스 가입 정보 연동 api 추가
3. 마이페이지 회원정보 메인 컨텐츠 영역 UI 구현
4. 로그인 안한 상태로 마이페이지 접근 시 뜨는 모달 및 로직 구현
5. 회원 탈퇴 모달 구현
6. 비밀번호 재설정 모달 구현(값이 다 채워져야만 버튼이 active 되도록)
7. 유플러스 가입 정보 연동 모달 구현
8. 멤버십 여부에 따라 달라지는 우측 사이드 컴포넌트화
9. 기존 마이페이지용 목데이터값을 api 구조에 맞게 수정


## 📷 스크린샷 (선택)

(로그인 안한 상태로 마이페이지 접근시)
![Animation9](https://github.com/user-attachments/assets/68185b13-1589-4154-b65f-9643aaae3299)

(멤버십 등급X 유저)
![Animation8](https://github.com/user-attachments/assets/14f20538-613a-46e4-9ab8-f3ba34c3574a)

(멤버십 등급O 유저)
<img width="1916" height="941" alt="스크린샷 2025-07-20 114556" src="https://github.com/user-attachments/assets/1543788f-745e-430a-b973-a8b6e082caaa" />


마이페이지 혜택 사용 이력 탭이랑 api연동까지 담주에 빠아아르게 마치겠슴다

## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
