### PR TITLE
헤더에 로그인상태 및 api 연동 완료/마이페이지 자잘한 변경사항

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3908,6 +3908,7 @@
           "url": "http://opencollective.com/swiper"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,11 +11,9 @@ import clsx from 'clsx';
 import { useLocation, Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import api from '../apis/axiosInstance';
-
-type HeaderProps = {
-  isLoggedIn?: boolean;
-  variant?: 'default' | 'glass';
-};
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../store';
+import { logout } from '../store/authSlice';
 
 const menus = [
   { id: 'intro', label: '잇플 소개', icon: TbSparkles, path: '/' },
@@ -24,14 +22,21 @@ const menus = [
   { id: 'mypage', label: '마이페이지', icon: TbUser, path: '/mypage/info' },
 ];
 
-export default function Header({ isLoggedIn = false, variant = 'default' }: HeaderProps) {
+export default function Header({ variant = 'default' }: { variant?: 'default' | 'glass' }) {
   const location = useLocation();
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const isLoggedIn = useSelector((state: RootState) => state.auth.isLoggedIn);
 
   const handleLogout = async () => {
     try {
-      await api.post('/logout'); // 🚨 추후 api완성된 후 경로 수정 필요
-      navigate('/main'); // 로그아웃 후 메인페이지로 이동
+      // 로그아웃 API 호출
+      await api.post('api/v1/auth/logout');
+      // 상태 초기화
+      dispatch(logout());
+      // 페이지 이동
+      navigate('/main');
     } catch (err) {
       console.error('로그아웃 실패:', err);
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,12 +8,14 @@ import {
   TbLayoutList,
 } from 'react-icons/tb';
 import clsx from 'clsx';
+import { useState } from 'react';
 import { useLocation, Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import api from '../apis/axiosInstance';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../store';
 import { logout } from '../store/authSlice';
+import Modal from './Modal';
 
 const menus = [
   { id: 'intro', label: '잇플 소개', icon: TbSparkles, path: '/' },
@@ -23,6 +25,8 @@ const menus = [
 ];
 
 export default function Header({ variant = 'default' }: { variant?: 'default' | 'glass' }) {
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+
   const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -39,74 +43,98 @@ export default function Header({ variant = 'default' }: { variant?: 'default' | 
       navigate('/main');
     } catch (err) {
       console.error('로그아웃 실패:', err);
+    } finally {
+      setShowLogoutModal(false); // 모달 닫기
     }
   };
 
   return (
-    <aside
-      className={clsx(
-        'fixed left-0 top-0 h-screen w-[81px] flex flex-col items-center py-4 rounded-tr-xl rounded-br-xl',
-        variant === 'glass' ? 'header-glass bg-[rgba(255,255,255,0.05)]' : 'bg-gradient-header'
-      )}
-    >
-      {/* 로고 영역 */}
-      <div className="mb-16 flex flex-col items-center text-white">
-        <TbMapPin
-          className="text-3xl mb-2 drop-shadow-[0_0_5px_rgba(255,255,255)]"
-          strokeWidth={1.3}
-        />
-        <span className="font-bold text-title-8 drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]">
-          IT: PLACE
-        </span>
-      </div>
-
-      {/* 메뉴들 */}
-      <nav className="flex-1 flex flex-col items-center gap-y-6">
-        {menus.map((m) => {
-          const Icon = m.icon;
-          const isActive =
-            m.id === 'mypage'
-              ? location.pathname.startsWith('/mypage')
-              : location.pathname === m.path;
-          return (
-            <Link
-              to={m.path}
-              key={m.id}
-              className={clsx(
-                'relative flex flex-col items-center justify-center text-white text-title-8 group w-[72px] h-[76px] hover:drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]'
-              )}
-            >
-              {/* 선택된 메뉴 하이라이트 */}
-              {isActive && (
-                <div className="absolute top-1/2 left-1/2 w-[72px] h-[76px] -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white opacity-25 -z-10 drop-shadow-basic"></div>
-              )}
-              <Icon className="text-3xl" />
-              <span className="mt-1">{m.label}</span>
-            </Link>
-          );
-        })}
-      </nav>
-
-      {/* 로그인 / 로그아웃 */}
-      <div className="mb-1">
-        {isLoggedIn ? (
-          <button
-            onClick={handleLogout}
-            className="flex flex-col items-center text-white text-sm hover:drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]"
-          >
-            <TbLogout className="text-3xl" strokeWidth={1.3} />
-            <span className="mt-1 text-title-8">로그아웃</span>
-          </button>
-        ) : (
-          <Link
-            to="/login"
-            className="flex flex-col items-center text-white text-title-8 hover:drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]"
-          >
-            <TbLogin className="text-3xl" strokeWidth={1.3} />
-            <span className="mt-1">로그인</span>
-          </Link>
+    <>
+      <aside
+        className={clsx(
+          'fixed left-0 top-0 h-screen w-[81px] flex flex-col items-center py-4 rounded-tr-xl rounded-br-xl',
+          variant === 'glass' ? 'header-glass bg-[rgba(255,255,255,0.05)]' : 'bg-gradient-header'
         )}
-      </div>
-    </aside>
+      >
+        {/* 로고 영역 */}
+        <div className="mb-16 flex flex-col items-center text-white">
+          <TbMapPin
+            className="text-3xl mb-2 drop-shadow-[0_0_5px_rgba(255,255,255)]"
+            strokeWidth={1.3}
+          />
+          <span className="font-bold text-title-8 drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]">
+            IT: PLACE
+          </span>
+        </div>
+
+        {/* 메뉴들 */}
+        <nav className="flex-1 flex flex-col items-center gap-y-6">
+          {menus.map((m) => {
+            const Icon = m.icon;
+            const isActive =
+              m.id === 'mypage'
+                ? location.pathname.startsWith('/mypage')
+                : location.pathname === m.path;
+            return (
+              <Link
+                to={m.path}
+                key={m.id}
+                className={clsx(
+                  'relative flex flex-col items-center justify-center text-white text-title-8 group w-[72px] h-[76px] hover:drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]'
+                )}
+              >
+                {/* 선택된 메뉴 하이라이트 */}
+                {isActive && (
+                  <div className="absolute top-1/2 left-1/2 w-[72px] h-[76px] -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white opacity-25 -z-10 drop-shadow-basic"></div>
+                )}
+                <Icon className="text-3xl" />
+                <span className="mt-1">{m.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* 로그인 / 로그아웃 */}
+        <div className="mb-1">
+          {isLoggedIn ? (
+            <button
+              onClick={() => setShowLogoutModal(true)}
+              className="flex flex-col items-center text-white text-sm hover:drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]"
+            >
+              <TbLogout className="text-3xl" strokeWidth={1.3} />
+              <span className="mt-1 text-title-8">로그아웃</span>
+            </button>
+          ) : (
+            <Link
+              to="/login"
+              className="flex flex-col items-center text-white text-title-8 hover:drop-shadow-[0_0_5px_rgba(255,255,255,0.6)]"
+            >
+              <TbLogin className="text-3xl" strokeWidth={1.3} />
+              <span className="mt-1">로그인</span>
+            </Link>
+          )}
+        </div>
+      </aside>
+
+      {/* ✅ 로그아웃 확인 모달 */}
+      <Modal
+        isOpen={showLogoutModal}
+        title="로그아웃"
+        message="로그아웃 하시겠습니까?"
+        onClose={() => setShowLogoutModal(false)}
+        buttons={[
+          {
+            label: '아니오',
+            type: 'secondary',
+            onClick: () => setShowLogoutModal(false),
+          },
+          {
+            label: '예',
+            type: 'primary',
+            onClick: handleLogout,
+          },
+        ]}
+      />
+    </>
   );
 }

--- a/src/features/myPage/components/BenefitDetailTabs.tsx
+++ b/src/features/myPage/components/BenefitDetailTabs.tsx
@@ -38,7 +38,7 @@ export default function BenefitDetailTabs({
       const myGrade = mockUser.membershipGrade;
       setSelectedGrade(myGrade);
     }
-  }, [benefitId]);
+  }, [benefitId, allBenefit, isVipKok]);
 
   // 🔹 공통된 스타일: 로고 카드
   function LogoBox({ image, alt }: { image: string; alt: string }) {

--- a/src/pages/myPage/MyFavoritesPage.tsx
+++ b/src/pages/myPage/MyFavoritesPage.tsx
@@ -59,7 +59,7 @@ export default function MyFavoritesPage() {
                 onClear={() => setKeyword('')}
                 width={280}
                 height={50}
-                backgroundColor="#f5f5f5"
+                backgroundColor="bg-grey01"
               />
             </div>
 

--- a/src/pages/myPage/MyInfoPage.tsx
+++ b/src/pages/myPage/MyInfoPage.tsx
@@ -10,9 +10,20 @@ import UserDeleteModal from '../../features/myPage/components/MyInfo/UserDeleteM
 import UplusLinkModal from '../../features/myPage/components/MyInfo/UplusLinkModal';
 import { loadUplusData } from '../../features/myPage/apis/uplus';
 
+interface User {
+  userId: number;
+  name: string;
+  email: string;
+  phoneNumber: string;
+  gender: string;
+  birthday: string;
+  membershipId: string;
+  membershipGrade: string;
+}
+
 export default function MyInfoPage() {
   // 실제로는 전역 상태에서 로그인 여부를 가져오면 됨
-  const [user, setUser] = useState<any>(null);
+  const [user, setUser] = useState<User | null>(null);
   const [isPwModalOpen, setIsPwModalOpen] = useState(false);
   const [currentPw, setCurrentPw] = useState('');
   const [newPw, setNewPw] = useState('');
@@ -20,7 +31,7 @@ export default function MyInfoPage() {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [password, setPassword] = useState('');
   const [showUplusModal, setShowUplusModal] = useState(false);
-  const [grade, setGrade] = useState<string | undefined>(user?.grade); // 초기 grade
+  const [grade, setGrade] = useState<string | undefined>(user?.membershipGrade); // 초기 grade
 
   useEffect(() => {
     // API 미연결로 mockData 사용
@@ -60,7 +71,7 @@ export default function MyInfoPage() {
           </div>
         }
         aside={
-          <FadeWrapper changeKey={user.grade}>
+          <FadeWrapper changeKey={user.membershipGrade}>
             <MembershipInfo
               name={user.name}
               grade={grade} //user.grade로 바꾸면 mockData상에서 멤버십등급을 가져와 변경된 UI 보기 가능


### PR DESCRIPTION
## 📝 변경 사항

1. 헤더에 로그인 상태 및 로그아웃 api 연동을 완료했습니다.
2. 마이페이지 타입오류를 임시로 해결했습니다. 추후 api가 확정되면 mockData가 아닌 실제 api 값으로 더 정확하게 타입을 지정할 예정입니다.
3. 검색바 컴포넌트가 변경되면서 사라진 검색바 배경을 다시 bg-grey01로 주었습니다.
4. 로그아웃 누르면 나오는 확인 모달 구현 했습니다.

<img width="1902" height="923" alt="image" src="https://github.com/user-attachments/assets/7ed82971-4b9d-4a64-b63b-81f1c5b84465" />


## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
