### PR TITLE
마이페이지 전반적인 UIUX 개선

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,27 +1,23 @@
 import React from 'react';
 import { TbSearch, TbX } from 'react-icons/tb';
-
 interface SearchBarProps {
   placeholder: string;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onClear: () => void;
-  width?: number;
-  height?: number;
+  className?: string;
   backgroundColor?: string;
 }
-
 const SearchBar: React.FC<SearchBarProps> = ({
   placeholder,
   value,
   onChange,
   onClear,
-  width = 344,
-  height = 50,
+  className = '',
   backgroundColor,
 }) => {
   return (
-    <div className="relative" style={{ width, height }}>
+    <div className={`relative ${className}`}>
       <div className="absolute left-4 top-1/2 transform -translate-y-1/2">
         <TbSearch size={18} className="text-purple04" />
       </div>
@@ -45,5 +41,4 @@ const SearchBar: React.FC<SearchBarProps> = ({
     </div>
   );
 };
-
 export default SearchBar;

--- a/src/features/mainPage/components/SidebarSection/SearchSection/index.tsx
+++ b/src/features/mainPage/components/SidebarSection/SearchSection/index.tsx
@@ -27,7 +27,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({ onSearchChange }) => {
         onChange={handleSearchChange}
         onClear={handleSearchClear}
         backgroundColor="bg-grey01"
-        width={330}
+        className="w-[330px] h-[50px]"
       />
     </div>
   );

--- a/src/features/myPage/components/Favorites/FavoritesAside.tsx
+++ b/src/features/myPage/components/Favorites/FavoritesAside.tsx
@@ -1,6 +1,7 @@
 import FadeWrapper from '../FadeWrapper';
 import BenefitDetailTabs from './BenefitDetailTabs';
 import { FavoriteItem } from '../../../../types/favorites';
+import LoadingSpinner from '../../../../components/LoadingSpinner';
 
 interface FavoritesAsideProps {
   favorites: FavoriteItem[];
@@ -8,6 +9,7 @@ interface FavoritesAsideProps {
   selectedItems: number[];
   selectedId: number | null;
   userGrade?: string;
+  loading: boolean;
 }
 
 export default function FavoritesAside({
@@ -16,7 +18,15 @@ export default function FavoritesAside({
   selectedItems,
   selectedId,
   userGrade,
+  loading,
 }: FavoritesAsideProps) {
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-full">
+        <LoadingSpinner />
+      </div>
+    );
+  }
   // 찜한 혜택이 아예 없을 때
   if (favorites.length === 0) {
     return (

--- a/src/features/myPage/hooks/useFavorites.ts
+++ b/src/features/myPage/hooks/useFavorites.ts
@@ -17,11 +17,15 @@ export function useFavorites(itemsPerPageInit = 6) {
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(itemsPerPageInit);
 
+  // 로딩 상태
+  const [loading, setLoading] = useState(false);
+
   // ✅ 전체 데이터 기반으로 totalElements 관리
   const totalElements = allFavorites.length;
 
   // ✅ 한 번에 전체 데이터를 불러오기
   const loadFavorites = useCallback(async () => {
+    setLoading(true);
     try {
       const category = benefitFilter === 'vipkok' ? 'VIP 콕' : '기본 혜택';
       // size를 충분히 크게 해서 전체 데이터를 한 번에 불러옴
@@ -30,6 +34,8 @@ export function useFavorites(itemsPerPageInit = 6) {
     } catch (err) {
       console.error('즐겨찾기 목록 불러오기 실패', err);
       setAllFavorites([]);
+    } finally {
+      setLoading(false);
     }
   }, [benefitFilter]);
 
@@ -98,6 +104,7 @@ export function useFavorites(itemsPerPageInit = 6) {
   };
 
   return {
+    loading,
     allFavorites,
     currentItems,
     totalElements,

--- a/src/pages/myPage/MyFavoritesPage.tsx
+++ b/src/pages/myPage/MyFavoritesPage.tsx
@@ -62,9 +62,8 @@ export default function MyFavoritesPage() {
                 value={keyword}
                 onChange={(e) => setKeyword(e.target.value)}
                 onClear={() => setKeyword('')}
-                width={280}
-                height={50}
                 backgroundColor="bg-grey01"
+                className="w-[280px] h-[50px]"
               />
             </div>
             {/* 편집/전체선택 컨트롤 */}

--- a/src/pages/myPage/MyFavoritesPage.tsx
+++ b/src/pages/myPage/MyFavoritesPage.tsx
@@ -1,5 +1,5 @@
 import { useFavorites } from '../../features/myPage/hooks/useFavorites';
-import { Pagination } from '../../components';
+import { LoadingSpinner, Pagination } from '../../components';
 import BenefitFilterToggle from '../../components/BenefitFilterToggle';
 import SearchBar from '../../components/SearchBar';
 import NoResult from '../../components/NoResult';
@@ -13,6 +13,7 @@ import { RootState } from '../../store';
 
 export default function MyFavoritesPage() {
   const {
+    loading,
     allFavorites,
     totalElements,
     currentItems,
@@ -96,7 +97,12 @@ export default function MyFavoritesPage() {
             {/* 카드 리스트 */}
             {/* 검색 결과가 없을 때는 "검색 결과 없음" 표시
             검색어가 없고 목록도 없을 때는 "찜한 혜택이 없음" 표시 */}
-            {keyword.trim() ? (
+            {loading ? (
+              // 로딩 중
+              <div className="flex justify-center items-center h-full">
+                <LoadingSpinner />
+              </div>
+            ) : keyword.trim() ? (
               currentItems.length === 0 ? (
                 <div className="mt-28">
                   <NoResult message1="검색 결과가 없어요." message2="다른 키워드로 검색해보세요." />
@@ -140,7 +146,7 @@ export default function MyFavoritesPage() {
                 }}
               />
             )}
-            {/* 페이지네이션 */}
+
             {/* 페이지네이션 */}
             {!(
               (keyword.trim() && currentItems.length === 0) || // 검색 중이고 결과가 0
@@ -188,6 +194,7 @@ export default function MyFavoritesPage() {
             selectedItems={selectedItems}
             selectedId={selectedId}
             userGrade={userGrade}
+            loading={loading}
           />
         }
         bottomImage="/images/myPage/bunny-favorites.webp"

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -190,7 +190,7 @@ export default function MyHistoryPage() {
                       <img
                         src={item.image}
                         alt={item.benefitName}
-                        className="h-[70px] w-auto object-contain flex-shrink-0"
+                        className="h-[70px] w-auto object-contain flex-shrink-0 ml-3"
                       />
                       <span
                         className="ml-2 text-purple05 text-title-5 font-semibold overflow-hidden text-ellipsis whitespace-nowrap block"
@@ -203,8 +203,8 @@ export default function MyHistoryPage() {
                       <span className="text-black text-title-5 font-semibold w-[120px] text-right">
                         {item.discountAmount.toLocaleString()}원
                       </span>
-                      <span className="text-grey05 text-body-1 px-4">
-                        {dayjs(item.usedAt).format('YYYY-MM-DD')}
+                      <span className="text-grey05 text-body-1 px-4 font-light">
+                        {dayjs(item.usedAt).format('YYYY-MM-DD HH:mm:ss')}
                       </span>
                     </div>
                   </div>

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -12,6 +12,7 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { RiResetRightFill } from 'react-icons/ri';
 import FadeWrapper from '../../features/myPage/components/FadeWrapper';
+import LoadingSpinner from '../../components/LoadingSpinner';
 
 interface HistoryItem {
   image: string;
@@ -46,6 +47,7 @@ export default function MyHistoryPage() {
     if (!membershipGrade) return; // 멤버십 없으면 호출 X
 
     const fetchHistory = async () => {
+      setLoading(true);
       try {
         const res = await api.get('/api/v1/membership-history', {
           params: {
@@ -73,6 +75,8 @@ export default function MyHistoryPage() {
         setHistory([]);
         setCurrentPage(0);
         setTotalElements(0);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -84,6 +88,7 @@ export default function MyHistoryPage() {
     if (!membershipGrade) return;
 
     const fetchSummary = async () => {
+      setLoading(true);
       try {
         const res = await api.get('/api/v1/membership-history/summary');
         const data = res.data?.data;
@@ -91,6 +96,8 @@ export default function MyHistoryPage() {
       } catch (err) {
         console.error('멤버십 요약 API 오류:', err);
         setTotalAmount(0);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -149,7 +156,12 @@ export default function MyHistoryPage() {
 
           {/* 📋 혜택 사용 이력 리스트 */}
           <div className="flex-grow">
-            {membershipGrade == null ? (
+            {loading ? (
+              // 로딩 중
+              <div className="flex justify-center items-center h-full">
+                <LoadingSpinner />
+              </div>
+            ) : membershipGrade == null ? (
               <div className="mt-28">
                 <NoResult
                   message1="앗! 멤버십 등급이 없어 결과를 조회할 수 없어요"
@@ -217,25 +229,32 @@ export default function MyHistoryPage() {
       }
       aside={
         <FadeWrapper changeKey={totalAmount.toLocaleString()}>
-          <div className="text-center">
-            <h1 className="text-title-2 text-black mb-4 text-center">이번 달에 받은 혜택 금액</h1>
-            <div className="flex flex-col items-center justify-center mt-6">
-              <img
-                src="/images/myPage/icon-money.webp"
-                alt="혜택 사용 이력 아이콘"
-                className="w-[250px] h-auto"
-                onError={(e) => {
-                  const target = e.target as HTMLImageElement;
-                  target.onerror = null;
-                  target.src = '/images/myPage/icon-money.png';
-                }}
-              />
-              <p className="text-[36px] font-semibold text-grey05 pt-10">
-                <span className="text-orange04">{totalAmount.toLocaleString()}</span>
-                원 <br /> 할인 받았어요!
-              </p>
+          {loading ? (
+            // 로딩 중
+            <div className="flex justify-center items-center mt-20 h-full">
+              <LoadingSpinner />
             </div>
-          </div>
+          ) : (
+            <div className="text-center">
+              <h1 className="text-title-2 text-black mb-4 text-center">이번 달에 받은 혜택 금액</h1>
+              <div className="flex flex-col items-center justify-center mt-6">
+                <img
+                  src="/images/myPage/icon-money.webp"
+                  alt="혜택 사용 이력 아이콘"
+                  className="w-[250px] h-auto"
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.onerror = null;
+                    target.src = '/images/myPage/icon-money.png';
+                  }}
+                />
+                <p className="text-[36px] font-semibold text-grey05 pt-10">
+                  <span className="text-orange04">{totalAmount.toLocaleString()}</span>
+                  원 <br /> 할인 받았어요!
+                </p>
+              </div>
+            </div>
+          )}
         </FadeWrapper>
       }
       bottomImage="/images/myPage/bunny-history.webp"

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -122,9 +122,8 @@ export default function MyHistoryPage() {
               value={keyword}
               onChange={(e) => setKeyword(e.target.value)}
               onClear={() => setKeyword('')}
-              width={280}
-              height={50}
               backgroundColor="bg-grey01"
+              className="w-[280px] h-[50px]"
             />
             <div className="flex gap-2 items-center">
               <button

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -21,22 +21,25 @@ interface HistoryItem {
 }
 
 export default function MyHistoryPage() {
-  // 🔥 Redux 상태에서 사용자 정보 가져오기
+  // Redux 상태에서 사용자 정보 가져오기
   const user = useSelector((state: RootState) => state.auth.user);
   const membershipGrade = user?.membershipGrade ?? null;
 
-  // 🔎 검색/필터/페이지네이션 상태
+  // 검색/필터/페이지네이션 상태
   const [keyword, setKeyword] = useState('');
   const [page, setPage] = useState(0); // 0-based
   const [size] = useState(5);
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
 
-  // 📦 API 데이터 상태
+  // API 데이터 상태
   const [history, setHistory] = useState<HistoryItem[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
   const [totalElements, setTotalElements] = useState(0);
   const [totalAmount, setTotalAmount] = useState(0);
+
+  // 로딩 상태
+  const [loading, setLoading] = useState(false);
 
   // ✅ 혜택 사용 이력 API 호출 (페이지/필터 변화 시 재호출)
   useEffect(() => {
@@ -83,7 +86,6 @@ export default function MyHistoryPage() {
     const fetchSummary = async () => {
       try {
         const res = await api.get('/api/v1/membership-history/summary');
-        console.log('📌 총 할인 금액 응답:', res.data);
         const data = res.data?.data;
         setTotalAmount(data?.totalDiscountAmount ?? 0);
       } catch (err) {


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1.필요없는 콘솔로그를 삭제
2. 혜택 이력 탭에 로딩 상태를 추가하여 더 부드러운 UI로 개선
3. 상위 컴포넌트에서 로딩 상태 전달할 수 있도록하여 전반적인 로딩 UI 자연스럽게 개선
4. isMounted 플래그를 추가해 빠르게 api 요청을 왔다갔다하는 상황에서 렌더링 결과가 섞이지 않게 함
5. 혜택 사용 이력에 시간도 표시하도록 수정 및 이미지와 텍스트 간격 조정

## 📷 스크린샷 (선택)
빠르게 api요청 왔다갔다할때(VIP콕/기본혜택) 섞이던 결과값들이 안정적으로 나오게 됐습니다.
![Animation10](https://github.com/user-attachments/assets/e529dffb-a0e7-4489-8a06-b03b201637e6)

<img width="1828" height="928" alt="image" src="https://github.com/user-attachments/assets/52cf9e39-648c-4c4c-a5b8-3231bd07ebc2" />


## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
