### PR TITLE
마이페이지 회원 탈퇴 및 비밀번호 변경 api 연결 완료

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -21,6 +21,7 @@ interface ModalProps {
   onClose: () => void;
   buttons?: ButtonType[];
   children?: React.ReactNode;
+  inputType?: string;
 }
 
 const Modal: React.FC<ModalProps> = ({
@@ -30,6 +31,7 @@ const Modal: React.FC<ModalProps> = ({
   subMessage = '',
   subMessageClass = '',
   input = false,
+  inputType = 'text',
   inputValue = '',
   inputPlaceholder = '',
   onInputChange,
@@ -87,7 +89,7 @@ const Modal: React.FC<ModalProps> = ({
         {/* 입력창 */}
         {input && (
           <input
-            type="text"
+            type={inputType}
             className="w-full max-w-[436px] h-[50px] mt-[20px] px-[20px] bg-grey01 rounded-[10px] text-body-2 text-grey05 placeholder-grey03 max-sm:text-body-3"
             placeholder={inputPlaceholder}
             value={inputValue}

--- a/src/features/myPage/components/MyInfo/UserDeleteModal.tsx
+++ b/src/features/myPage/components/MyInfo/UserDeleteModal.tsx
@@ -19,6 +19,7 @@ export default function UserDeleteModal({
   return (
     <Modal
       isOpen={isOpen}
+      inputType="password"
       title="정말 탈퇴하시겠습니까?"
       message="탈퇴를 위해 현재 비밀번호를 입력해주세요."
       input


### PR DESCRIPTION
## 📝 변경 사항

1. 모달 컴포넌트에 input의 type을 지정할 수 있도록 props를 추가했습니다. (기본값이 text로 고정되어있어서, 비밀번호 input을 받을때 그대로 노출되는 문제가 발생해 추가)
2. 회원 삭제 및 비밀번호 변경 api 연결을 완료했고, 테스트도 마쳤습니다.

## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
