### PR TITLE
mobile header bug fix 및 자잘한 문제점 해결

### DIFF
--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -65,7 +65,7 @@ const MobileHeader = ({
     <>
       <header
         className={
-          `w-full h-[54px] fixed top-0 left-0 flex items-center px-4 z-[9999] border-grey01 max-md:flex ${backgroundColor}` +
+          `w-full h-[54px] fixed top-0 left-0 flex items-center px-4 z-[9999] border-grey01 max-md:flex ${backgroundColor} ` +
           (isMain ? 'border-b-none' : 'border-b')
         }
       >

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -6,7 +6,7 @@ import 'react-toastify/dist/ReactToastify.css';
 const ToastProvider: React.FC = () => {
   return (
     <ToastContainer
-      position="bottom-center"
+      position="top-center"
       autoClose={3000}
       hideProgressBar={true}
       closeOnClick

--- a/src/features/loginPage/layouts/AuthLayout.tsx
+++ b/src/features/loginPage/layouts/AuthLayout.tsx
@@ -255,7 +255,7 @@ const AuthLayout = () => {
       </Modal>
 
       {/* 모바일 레이아웃 (max-md: ~767px) */}
-      <div className="max-md:block hidden w-full h-screen relative fixed max-md:fixed max-md:inset-0 max-sm:block max-sm:fixed max-sm:inset-0">
+      <div className="max-md:block hidden w-full h-screen fixed max-md:fixed max-md:inset-0 max-sm:block max-sm:fixed max-sm:inset-0">
         {/* 배경 SideCard - 전체 화면 */}
         <div className="absolute top-0 left-0 w-full h-2/3">
           <AuthSideCard />

--- a/src/features/myPage/components/SideMenu.tsx
+++ b/src/features/myPage/components/SideMenu.tsx
@@ -78,7 +78,7 @@ export default function SideMenu() {
         className="
           hidden
           max-md:flex
-          sticky top-0 z-50
+          fixed top-0 z-50 mt-[53px]
           w-full
           bg-white
           border-b border-grey03

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -4,7 +4,7 @@ import { Outlet } from 'react-router-dom';
 const MobileLayout = () => {
   return (
     <div className="max-md:block hidden bg-white min-h-screen">
-      <main className="px-5">
+      <main className="px-5 mt-[54px]">
         <Outlet />
       </main>
     </div>

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -1,11 +1,9 @@
 // src/layouts/MobileLayout.tsx
 import { Outlet } from 'react-router-dom';
-import MobileHeader from '../components/MobileHeader';
 
 const MobileLayout = () => {
   return (
     <div className="max-md:block hidden bg-white min-h-screen">
-      <MobileHeader />
       <main className="px-5">
         <Outlet />
       </main>

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -41,13 +41,13 @@ export default function MyPageLayout() {
   // ✅ 로그인된 경우에는 마이페이지 레이아웃 정상 렌더
   return (
     <div>
-      <div className="fixed top-0 left-0 w-full z-[9999] max-md:block hidden">
+      <div className="hidden fixed top-0 left-0 w-full z-[9999] max-md:block">
         <MobileHeader title="마이잇플" />
       </div>
 
       <div
         className={
-          `min-h-screen max-h-screen bg-grey01 p-[28px] flex gap-[28px] max-md:-mx-5 max-md:max-h-none max-md:flex-col max-md:p-0` +
+          `min-h-screen max-h-screen bg-grey01 p-[28px] flex gap-[28px] max-md:-mx-5 max-md:max-h-none max-md:flex-col max-md:p-0 max-md:pt-[48px]` +
           (isSimpleLayout ? ' max-md:gap-0 max-md:bg-white' : '')
         }
       >

--- a/src/pages/myPage/MyInfoPage.tsx
+++ b/src/pages/myPage/MyInfoPage.tsx
@@ -100,7 +100,7 @@ export default function MyInfoPage() {
   }
 
   return (
-    <div className="flex flex-row gap-[28px] w-full h-full max-md:flex-col-reverse max-md:px-5 max-md:pb-7">
+    <div className="flex flex-row gap-[28px] w-full h-full max-md:flex-col-reverse max-md:px-5 max-md:pb-7 max-md:pt-[20px]">
       <MyPageContentLayout
         main={
           <div>

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -65,9 +65,12 @@ export function showToast(
     ...options?.style, // 여기에 사용자가 넘긴 width만 덮어쓰기
   };
 
+  // ✅ 모바일인지 아닌지 판별 (500px 이하를 모바일로 간주)
+  const isMobile = window.innerWidth <= 500;
+
   toast(message, {
     ...options, // ✅ 먼저 사용자가 전달한 옵션을 펼치기
-    position: options?.position || 'top-center',
+    position: options?.position || (isMobile ? 'bottom-center' : 'top-center'),
     icon,
     ...toastStyles[type],
     style: customStyle, // ✅ 맨 마지막에 최종 스타일을 덮어쓰기


### PR DESCRIPTION
## 📝 변경 사항

1. 공통레이아웃에서 1번, 각 페이지에서 1번 총 2번 불러와져서 두개씩 겹쳐보이던 모바일 헤더 버그를 수정
2. 모바일 헤더 배경 default색상이 white임에도 계속 투명으로 보이던 버그를 해결
3. AuthLayout에 공통된 css속성이 한 줄에 두번 사용되어 뜨던 노란밑줄 경고를 해결
4. 모바일에서 토스트위치가 너무 안보여서 모바일에서는 bottom-center로 뜨도록 수정

## 📷 스크린샷 (선택)

**(모바일 헤더 버그 수정 전)** - 스크롤을 끝까지 당기면 두개의 헤더가 보임
<img width="920" height="479" alt="스크린샷 2025-07-28 104854" src="https://github.com/user-attachments/assets/745a41cb-8184-4339-b57e-b1bad3942261" />


**(모바일 헤더 버그 수정 전)** - 배경이 투명으로 되어있어 뒤의 내용이 보임
<img width="977" height="123" alt="스크린샷 2025-07-28 104949" src="https://github.com/user-attachments/assets/8469aa3a-fa0a-45ff-93fc-77ef16c41d4a" />



**(모바일 헤더 버그 해결 완료)**
<img width="383" height="424" alt="image" src="https://github.com/user-attachments/assets/f65b3f59-0d0a-4c62-b6ae-b10f730d1a44" />


**(모바일 토스트 위치 수정 전)**
<img width="384" height="815" alt="스크린샷 2025-07-28 100024" src="https://github.com/user-attachments/assets/53d97bca-c887-4c5c-a50d-7d434aaedbbe" />


**(모바일 토스트 위치 수정 후)**
<img width="404" height="794" alt="스크린샷 2025-07-28 102153" src="https://github.com/user-attachments/assets/2a9f34bf-9541-45eb-a6d8-fd2612d86c46" />

## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
