### PR TITLE
진짜로 레전드 맛도리 마이페이지 반응형

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -54,7 +54,7 @@ export default function Header({ variant = 'default' }: { variant?: 'default' | 
     <>
       <aside
         className={clsx(
-          'fixed z-30 left-0 top-0 h-screen overflow-y-auto scrollbar-hide w-[81px] flex flex-col items-center py-4 rounded-tr-xl rounded-br-xl',
+          'fixed z-30 left-0 top-0 h-full overflow-y-auto scrollbar-hide w-[81px] flex flex-col items-center py-4 rounded-tr-xl rounded-br-xl',
           variant === 'glass' ? 'header-glass bg-[rgba(255,255,255,0.05)]' : 'bg-gradient-header'
         )}
       >

--- a/src/features/allBenefitsPage/components/EventBanner.tsx
+++ b/src/features/allBenefitsPage/components/EventBanner.tsx
@@ -11,7 +11,7 @@ const EventBanner: React.FC = () => {
 
   useEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth <= 767); // max-sm 기준
+      setIsMobile(window.innerWidth <= 767); // max-md 기준
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);

--- a/src/features/allBenefitsPage/components/EventBanner.tsx
+++ b/src/features/allBenefitsPage/components/EventBanner.tsx
@@ -7,11 +7,11 @@ const images = ['/images/allBenefits/event1.png', '/images/allBenefits/event2.pn
 const images2 = ['/images/allBenefits/event1-1.png', '/images/allBenefits/event2-2.png'];
 
 const EventBanner: React.FC = () => {
-  const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth <= 500);
+  const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth <= 767);
 
   useEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth <= 500); // max-sm 기준
+      setIsMobile(window.innerWidth <= 767); // max-sm 기준
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
@@ -20,7 +20,7 @@ const EventBanner: React.FC = () => {
   const renderImages = isMobile ? images2 : images;
 
   return (
-    <div className="rounded-[18px] max-xl:rounded-[14px] drop-shadow-basic flex items-center justify-center w-[1200px] max-xl:w-[950px] h-[250px] max-xl:h-[200px] max-md:w-full max-md:h-[100px] max-md:rounded-none max-md:drop-shadow-none">
+    <div className="rounded-[18px] max-xl:rounded-[14px] drop-shadow-basic flex items-center justify-center w-[1190px] max-xl:w-[950px] h-[250px] max-xl:h-[200px] max-md:w-full max-md:h-[100px] max-md:rounded-none max-md:drop-shadow-none">
       <Swiper
         modules={[Navigation, Pagination, Autoplay]}
         spaceBetween={30}

--- a/src/features/mainPage/components/Layout/index.tsx
+++ b/src/features/mainPage/components/Layout/index.tsx
@@ -291,7 +291,7 @@ const MainPageLayout: React.FC = () => {
 
   // 모바일에서 body 스크롤 방지
   useEffect(() => {
-    const isMobile = window.innerWidth < 768;
+    const isMobile = window.innerWidth < 767;
     if (isMobile) {
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';

--- a/src/features/myPage/components/MainContentWrapper.tsx
+++ b/src/features/myPage/components/MainContentWrapper.tsx
@@ -15,7 +15,7 @@ export default function MainContentWrapper({ children }: MainContentWrapperProps
     'flex flex-1 flex-col max-w-[881px] h-full max-h-[891px] bg-white rounded-[18px] drop-shadow-basic pt-[76px] pb-[56px] pl-[56px] pr-[56px] max-xl:pt-[56px] max-xl:pb-[40px] max-xlg:pt-[36px] max-xlg:pb-[32px] max-xlg:px-[28px] ' +
     (isSimpleLayout
       ? // 모바일 favorites / history 전용: 그림자, radius 제거 + 패딩 제거
-        'max-md:rounded-none max-md:drop-shadow-none max-md:px-6 max-md:pb-6'
+        'max-md:rounded-none max-md:drop-shadow-none max-md:px-0 max-md:pb-6'
       : // 모바일 myInfo 전용: radius, 그림자 유지 + 모바일 패딩
         'max-md:p-6');
 

--- a/src/features/myPage/components/MainContentWrapper.tsx
+++ b/src/features/myPage/components/MainContentWrapper.tsx
@@ -12,7 +12,7 @@ export default function MainContentWrapper({ children }: MainContentWrapperProps
     pathname.startsWith('/mypage/favorites') || pathname.startsWith('/mypage/history');
 
   const className =
-    'flex flex-1 flex-col max-w-[881px] h-full max-h-[891px] bg-white rounded-[18px] drop-shadow-basic pt-[76px] pb-[56px] pl-[56px] pr-[56px] max-xl:pt-[56px] max-xl:pb-[40px] max-xlg:pt-[36px] max-xlg:pb-[32px] max-xlg:px-[28px] ' +
+    'flex flex-1 flex-col max-w-[881px] h-full max-h-[891px] max-xlg:max-h-none bg-white rounded-[18px] drop-shadow-basic pt-[76px] pb-[56px] pl-[56px] pr-[56px] max-xl:pt-[56px] max-xl:pb-[40px] max-xlg:pt-[36px] max-xlg:pb-[32px] max-xlg:px-[28px] ' +
     (isSimpleLayout
       ? // 모바일 favorites / history 전용: 그림자, radius 제거 + 패딩 제거
         'max-md:rounded-none max-md:drop-shadow-none max-md:px-0 max-md:pb-6'

--- a/src/features/myPage/components/MyInfo/UserInfoForm.tsx
+++ b/src/features/myPage/components/MyInfo/UserInfoForm.tsx
@@ -22,7 +22,7 @@ const UserInfoForm: React.FC<Props> = ({
 }) => {
   return (
     <div className="flex justify-center mt-[100px] max-xl:mt-[60px] max-xlg:mt-[30px] max-md:mt-0">
-      <div className="flex flex-col gap-4 w-full max-w-[690px] min-w-[590px] max-xl:max-w-[30.625rem] max-xl:min-w-[370px] max-xlg:w-full">
+      <div className="flex flex-col gap-4 w-full max-w-[690px] min-w-[590px] max-xl:max-w-[30.625rem] max-xl:min-w-[370px] max-xlg:w-full max-md:min-w-0">
         <InfoRow label="이름" value={name} />
         <InfoRow label="성별" value={gender === 'MALE' ? '남성' : '여성'} />
         <InfoRow label="생년월일" value={birthday.replace(/-/g, '.')} />

--- a/src/features/myPage/components/RightAside.tsx
+++ b/src/features/myPage/components/RightAside.tsx
@@ -25,7 +25,7 @@ export default function RightAside({
   return (
     <aside
       className={
-        'max-h-[891px] w-full max-w-[476px] min-w-[400px] bg-white rounded-[18px] drop-shadow-basic pt-[76px] pb-[56px] px-[40px] flex flex-col max-xl:max-w-[390px] max-xl:min-w-[320px] max-xl:pt-[56px] max-xlg:max-w-none max-xlg:w-full max-xlg:min-w-[240px] max-xlg:pt-[36px] max-xlg:pb-[32px] max-xlg:px-[28px] max-md:w-full max-md:p-6 ' +
+        'max-h-[891px] max-xlg:max-h-none w-full max-w-[476px] min-w-[400px] bg-white rounded-[18px] drop-shadow-basic pt-[76px] pb-[56px] px-[40px] flex flex-col max-xl:max-w-[390px] max-xl:min-w-[320px] max-xl:pt-[56px] max-xlg:max-w-none max-xlg:w-full max-xlg:min-w-[240px] max-xlg:pt-[36px] max-xlg:pb-[32px] max-xlg:px-[28px] max-md:w-full max-md:p-6 ' +
         (isSimpleLayout ? ' max-md:hidden' : '')
       }
     >

--- a/src/features/myPage/components/SideMenu.tsx
+++ b/src/features/myPage/components/SideMenu.tsx
@@ -33,7 +33,7 @@ export default function SideMenu() {
   return (
     <>
       {/* ✅ 데스크탑용 사이드 메뉴*/}
-      <aside className="max-h-[891px] w-full max-w-[370px] bg-white rounded-[18px] drop-shadow-basic pt-[76px] pb-[56px] px-3 max-xl:max-w-[310px] max-xl:pt-[56px] max-xlg:max-w-[220px] max-xlg:min-w-[180px] max-xlg:pt-[36px] max-md:hidden">
+      <aside className="max-h-[891px] max-xlg:max-h-none w-full max-w-[370px] bg-white rounded-[18px] drop-shadow-basic pt-[76px] pb-[56px] px-3 max-xl:max-w-[310px] max-xl:pt-[56px] max-xlg:max-w-[220px] max-xlg:min-w-[180px] max-xlg:pt-[36px] max-md:hidden">
         <h1 className="text-title-1 text-purple06 pl-[34px] pb-[80px] max-xl:text-title-2 max-xl:pb-[60px] max-xlg:pl-4 max-lg:pl-2">
           MY PAGE
         </h1>

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -32,7 +32,6 @@ export default function MyPageLayout() {
         isOpen={showLoginModal}
         onClose={() => {
           setShowLoginModal(false);
-          // 필요하다면 다른 로직
         }}
       />
     );

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -46,7 +46,7 @@ export default function MyPageLayout() {
 
       <div
         className={
-          `min-h-screen bg-grey01 mx-auto p-[28px] flex gap-[28px] max-md:-mx-5 max-md:max-h-none max-md:flex-col max-md:p-0 max-md:pt-[48px]` +
+          `min-h-screen bg-grey01 mx-auto p-[28px] flex gap-[28px] max-lg:gap-[16px] max-md:-mx-5 max-md:max-h-none max-md:flex-col max-md:p-0 max-md:pt-[48px]` +
           (isWhiteLayout ? ' max-md:gap-0 max-md:bg-white' : '')
         }
       >

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -11,7 +11,7 @@ import { useMediaQuery } from 'react-responsive';
 export default function MyPageLayout() {
   const { pathname } = useLocation();
 
-  const isMobile = useMediaQuery({ query: '(max-width: 768px)' });
+  const isMobile = useMediaQuery({ query: '(max-width: 767px)' });
   const isHistory = pathname.startsWith('/mypage/history');
 
   // ✅ 모바일 레이아웃을 위한 조건분기

--- a/src/pages/myPage/MyFavoritesPage.tsx
+++ b/src/pages/myPage/MyFavoritesPage.tsx
@@ -166,7 +166,7 @@ export default function MyFavoritesPage() {
               (keyword.trim() && currentItems.length === 0) || // 검색 중이고 결과가 0
               (!keyword.trim() && allFavorites.length === 0) // 검색 안 했는데 전체도 0
             ) && (
-              <div className="mt-auto relative flex justify-center items-end max-md:mt-3">
+              <div className="mt-auto relative flex justify-center items-end max-md:mt-3 max-md:mb-2">
                 <Pagination
                   currentPage={currentPage}
                   itemsPerPage={itemsPerPage}
@@ -226,7 +226,7 @@ export default function MyFavoritesPage() {
               setIsEditing(false);
               setSelectedItems([]);
             }}
-            className="px-7 py-3 rounded-[12px] bg-white border border-grey02 text-grey03 text-body-2 font-medium"
+            className="px-7 py-3 rounded-[12px] bg-white border border-grey02 text-grey03 text-body-3 font-medium"
           >
             취소
           </button>
@@ -239,7 +239,7 @@ export default function MyFavoritesPage() {
                 setIsDeleteModalOpen(true);
               }
             }}
-            className={`flex-1 py-3 ml-3 rounded-[12px] text-body-1 font-medium text-white transition-colors ${
+            className={`flex-1 py-3 ml-3 rounded-[12px] text-body-3 font-medium text-white transition-colors ${
               selectedItems.length > 0 ? 'bg-purple04' : 'bg-grey03 text-grey04'
             }`}
           >

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -252,7 +252,7 @@ export default function MyHistoryPage() {
 
             {/* 페이지네이션 */}
             {
-              <div className="mt-auto flex justify-center">
+              <div className="mt-auto flex justify-center max-md:mb-6">
                 <Pagination
                   currentPage={currentPage + 1} // 0-based → 1-based
                   itemsPerPage={size}

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -48,7 +48,7 @@ export default function MyHistoryPage() {
   // 로딩 상태
   const [loading, setLoading] = useState(false);
 
-  const isMobile = useMediaQuery({ query: '(max-width: 768px)' });
+  const isMobile = useMediaQuery({ query: '(max-width: 767px)' });
 
   // ✅ 혜택 사용 이력 API 호출 (페이지/필터 변화 시 재호출)
   useEffect(() => {

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -126,18 +126,18 @@ export default function MyHistoryPage() {
         main={
           <div className="flex flex-col h-full">
             {/* 상단 타이틀 */}
-            <h1 className="text-title-2 text-black mb-7 max-xl:text-title-4 max-xl:mb-4 max-xl:font-semibold max-md:hidden">
+            <h1 className="text-title-2 text-black mb-7 max-xl:text-title-4 max-xl:font-semibold max-md:hidden">
               혜택 사용 이력
             </h1>
             {/* 🔎 검색바 + 날짜필터 */}
-            <div className="flex justify-between mb-8 gap-2 max-md:flex-col max-md:-mt-8">
+            <div className="flex justify-between mb-8 gap-2 max-xlg:flex-col max-md:-mt-8">
               <SearchBar
                 placeholder="혜택명으로 검색하기"
                 value={keyword}
                 onChange={(e) => setKeyword(e.target.value)}
                 onClear={() => setKeyword('')}
                 backgroundColor="bg-grey01"
-                className="w-[280px] h-[50px] max-xl:max-w-[220px] max-xl:h-[44px] max-xlg:max-w-[180px] max-md:max-w-none max-md:w-full max-md:mb-2"
+                className="w-[280px] h-[50px] max-xl:max-w-[220px] max-xl:h-[44px] max-xlg:max-w-none max-xlg:w-full max-md:mb-2"
               />
               <div className="flex gap-2 items-center justify-end">
                 <button
@@ -154,7 +154,7 @@ export default function MyHistoryPage() {
                   onChange={(date) => setStartDate(date)}
                   dateFormat="yyyy-MM-dd"
                   placeholderText="시작 날짜"
-                  className="border border-grey03 rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[90px] max-xlg:w-[80px] max-md:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
+                  className="border border-grey03 rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[90px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
                 />
                 <span className="text-grey05">~</span>
                 <DatePicker
@@ -162,7 +162,7 @@ export default function MyHistoryPage() {
                   onChange={(date) => setEndDate(date)}
                   dateFormat="yyyy-MM-dd"
                   placeholderText="종료 날짜"
-                  className="border border-grey03 rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[90px] max-xlg:w-[80px] max-md:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
+                  className="border border-grey03 rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[90px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
                 />
               </div>
             </div>
@@ -223,11 +223,11 @@ export default function MyHistoryPage() {
                           key={idx}
                           className="flex items-center border border-purple02 rounded-[10px] p-2"
                         >
-                          <div className="flex items-center gap-4 flex-1 min-w-0">
+                          <div className="flex items-center gap-4 flex-1 min-w-0 min-h-[40px]">
                             <img
                               src={item.image}
                               alt={item.benefitName}
-                              className="h-[70px] w-auto object-contain flex-shrink-0 ml-3 max-xl:h-[50px]"
+                              className="h-[70px] w-auto object-contain flex-shrink-0 ml-3 max-xl:h-[50px] max-lg:hidden"
                             />
                             <span
                               className="ml-2 text-purple05 text-title-5 font-semibold overflow-hidden text-ellipsis whitespace-nowrap block max-xl:text-title-7 max-xl:font-semibold"
@@ -280,14 +280,14 @@ export default function MyHistoryPage() {
                   <img
                     src="/images/myPage/icon-money.webp"
                     alt="혜택 사용 이력 아이콘"
-                    className="w-[250px] h-auto max-xl:w-[160px] max-lg:w-[130px]"
+                    className="w-[250px] h-auto max-xl:w-[160px] max-lg:w-[100px]"
                     onError={(e) => {
                       const target = e.target as HTMLImageElement;
                       target.onerror = null;
                       target.src = '/images/myPage/icon-money.png';
                     }}
                   />
-                  <p className="text-[36px] font-semibold text-grey05 pt-10 max-xl:text-[28px] max-xl:pt-6">
+                  <p className="text-[36px] font-semibold text-grey05 pt-10 max-xl:text-[28px] max-xl:pt-6 max-xlg:text-[24px]">
                     <span className="text-orange04">{totalAmount.toLocaleString()}</span>
                     원 <br className="max-lg:hidden" /> 할인 받았어요!
                   </p>

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -65,8 +65,8 @@ export function showToast(
     ...options?.style, // 여기에 사용자가 넘긴 width만 덮어쓰기
   };
 
-  // ✅ 모바일인지 아닌지 판별 (500px 이하를 모바일로 간주)
-  const isMobile = window.innerWidth <= 500;
+  // ✅ 모바일인지 아닌지 판별 (767px 이하를 모바일로 간주)
+  const isMobile = window.innerWidth <= 767;
 
   toast(message, {
     ...options, // ✅ 먼저 사용자가 전달한 옵션을 펼치기


### PR DESCRIPTION
## 📝 변경 사항

1. 테일윈드 컨피그 기준에 맞춰 여기저기 사용중인 isMobile에 768로 되어있는 부분을 모두 767px이하로 바꿈(랜딩페이지용 제외)
2. 혜택 이력, 관심 혜택 모바일 레이아웃 깨짐 해결
3. 회원정보 탭 모바일 min-w값 제거해서 레이아웃 깨짐 해결
4. 헤더 컴포넌트 h-screen에서 h-full로 수정
5. 마이페이지 반응형 최종

## 🔍 변경 사항 세부 설명

크롬기준에 있는 모든 기기에서 레이아웃이 깨지지않도록 정갈한 디자인으로(?) 수정했고, 그외에도 직접 화면을 이리저리 줄여서 보았을때도 잘 보이도록 구현했습니다.

## 📷 스크린샷 (선택)
![mypage](https://github.com/user-attachments/assets/84228fab-7810-4f37-9abf-6b571741a266)


## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
