### PR TITLE
fix: 마이페이지 타임존 문제 해결

### DIFF
--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -3,6 +3,11 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import api from '../../apis/axiosInstance';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 import MyPageContentLayout from '../../features/myPage/layout/MyPageContentLayout';
 import Pagination from '../../components/Pagination';
@@ -241,7 +246,10 @@ export default function MyHistoryPage() {
                               {item.discountAmount.toLocaleString()}원
                             </span>
                             <span className="text-grey05 text-body-1 px-4 font-light max-xl:text-body-3 max-xl:font-light max-xl:px-3 max-xlg:text-body-5 max-lg:text-body-4">
-                              {dayjs(item.usedAt).format('YYYY-MM-DD HH:mm:ss')}
+                              {dayjs
+                                .utc(item.usedAt)
+                                .tz('Asia/Seoul')
+                                .format('YYYY-MM-DD HH:mm:ss')}
                             </span>
                           </div>
                         </div>


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. dayjs의 utc, timezone 플러그인으로 마이페이지에서 9시간 늦게 찍히는 버그를 해결하였습니다.

## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
