### PR TITLE
Fix/마이페이지 시차 이슈 해결 및 달력 커스텀 & 반응형 처리

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,13 +23,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Anton&display=swap" rel="stylesheet" />
-    <link rel="preload" as="image" href="/images/landing/hero/hero-bg.webp" type="image/webp" />
-    <link
-      rel="preload"
-      as="image"
-      href="/images/landing/hero/hero-bg-mobile.webp"
-      type="image/webp"
-    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -236,3 +236,22 @@
     right: 10px;
   }
 }
+
+@media (max-width: 500px) {
+  /* 모바일에서 키보드 입력 방지 */
+  .react-datepicker__input-container input {
+    caret-color: transparent !important;
+    user-select: none !important;
+    -webkit-user-select: none !important;
+    -webkit-touch-callout: none !important;
+    -webkit-tap-highlight-color: transparent !important;
+  }
+  .react-datepicker-popper {
+    position: fixed !important;
+    top: 45% !important;
+    left: 50% !important;
+    transform: translate(-50%, -50%) !important;
+    z-index: 9999 !important;
+    width: auto !important;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -185,3 +185,54 @@
 .react-datepicker-popper[data-placement^='top'] .react-datepicker__triangle {
   display: none;
 }
+
+@media (max-width: 767px) {
+  .react-datepicker__current-month {
+    font-size: 14px;
+  }
+  .react-datepicker__day-names {
+    margin-top: 16px;
+  }
+  .react-datepicker__day-name {
+    color: #a175ff;
+    width: 20px;
+    height: 20px;
+    line-height: 20px;
+    font-size: 12px;
+  }
+  .react-datepicker__day {
+    width: 20px;
+    height: 20px;
+    line-height: 20px;
+    font-size: 12px;
+  }
+  /* 날짜 호버 효과 */
+  .react-datepicker__day:hover {
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+    border-radius: 20px !important;
+    background-color: #f3f4f6;
+    color: black;
+  }
+
+  /* 선택된 날짜 */
+  .react-datepicker__day--selected,
+  .react-datepicker__day--selected:hover,
+  .react-datepicker__day--keyboard-selected,
+  .react-datepicker__day--keyboard-selected:hover,
+  .react-datepicker .react-datepicker__month .react-datepicker__day--selected,
+  .react-datepicker .react-datepicker__month .react-datepicker__day--selected:hover {
+    width: 20px !important;
+    height: 20px !important;
+    line-height: 20px !important;
+  }
+
+  .react-datepicker__navigation--previous {
+    left: 10px;
+  }
+
+  .react-datepicker__navigation--next {
+    right: 10px;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -263,27 +263,22 @@
   }
   /* 모바일일 경우 대략 가운데 위치 */
   .react-datepicker-popper {
-    position: fixed !important;
-    top: 45% !important;
-    left: 53% !important;
+    position: absolute !important;
+    top: 250px !important;
+    left: 50% !important;
     transform: translate(-50%, -50%) !important;
     z-index: 9999 !important;
     width: auto !important;
   }
 
   .react-datepicker {
-    width: 80vw !important;
-    max-width: 320px !important; /* 최대 너비 제한 */
-    min-width: 280px !important; /* 최소 너비 보장 */
+    width: 90vw !important;
+    min-width: 280px !important;
   }
 
-  /* 요일 라인 */
   .react-datepicker__day-names {
-    display: flex;
-    justify-content: space-around;
-    margin-left: 6px;
-    margin-right: 6px;
-    margin-top: 20px;
+    margin-left: 0px;
+    margin-right: 0px;
   }
 
   /* 요일 */
@@ -300,5 +295,9 @@
     display: flex;
     flex-direction: column;
     background-color: white;
+  }
+
+  .react-datepicker__week {
+    gap: 20px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -256,7 +256,7 @@
   /* 모바일일 경우 대략 가운데 위치 */
   .react-datepicker-popper {
     position: absolute !important;
-    top: 250px !important;
+    top: 270px !important;
     left: 50% !important;
     transform: translate(-50%, -50%) !important;
     z-index: 9999 !important;
@@ -291,5 +291,6 @@
 
   .react-datepicker__week {
     gap: 20px;
+    margin-bottom: 8px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -83,3 +83,105 @@
 .scrollArea::-webkit-scrollbar-track {
   background-color: transparent;
 }
+
+.react-datepicker {
+  font-family: inherit;
+  border: none;
+  box-shadow: 2px 4px 8px 3px rgba(0, 0, 0, 0.1);
+  background-color: white;
+  padding: 12px 0px;
+}
+
+.react-datepicker__header {
+  background-color: white;
+  border-bottom: none;
+}
+
+.react-datepicker__current-month {
+  color: #a175ff;
+  font-size: 16px;
+}
+
+.react-datepicker__day-names {
+  margin-top: 20px;
+}
+
+.react-datepicker__day-name {
+  color: #a175ff;
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  font-size: 14px;
+}
+
+.react-datepicker__month {
+  padding: 8px;
+  background-color: white;
+}
+
+.react-datepicker__week {
+  display: flex;
+  justify-content: space-around;
+}
+
+.react-datepicker__day {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  border-radius: 20px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  font-size: 14px;
+  text-align: center;
+}
+
+/* 날짜 호버 효과 */
+.react-datepicker__day:hover {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  border-radius: 20px !important;
+  background-color: #f3f4f6;
+  color: black;
+}
+
+/* 선택된 날짜 */
+.react-datepicker__day--selected,
+.react-datepicker__day--selected:hover,
+.react-datepicker__day--keyboard-selected,
+.react-datepicker__day--keyboard-selected:hover,
+.react-datepicker .react-datepicker__month .react-datepicker__day--selected,
+.react-datepicker .react-datepicker__month .react-datepicker__day--selected:hover {
+  background-color: #cdb5ff !important;
+  color: white !important;
+  border-radius: 20px !important;
+  width: 32px !important;
+  height: 32px !important;
+  line-height: 32px !important;
+}
+
+.react-datepicker__navigation {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  position: absolute;
+  top: 14px;
+  transition: background-color 0.2s ease;
+}
+
+.react-datepicker__navigation--previous {
+  left: 12px;
+}
+
+.react-datepicker__navigation--next {
+  right: 12px;
+}
+
+.react-datepicker-popper {
+  z-index: 1000;
+}
+
+.react-datepicker-popper[data-placement^='bottom'] .react-datepicker__triangle,
+.react-datepicker-popper[data-placement^='top'] .react-datepicker__triangle {
+  display: none;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -84,28 +84,39 @@
   background-color: transparent;
 }
 
+/* 달력 컨테이너 */
 .react-datepicker {
   font-family: inherit;
   border: none;
   box-shadow: 2px 4px 8px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
-  padding: 12px 0px;
+  padding: 12px 8px;
+  display: flex;
+  justify-content: center;
 }
 
+/* 달력 헤더 */
 .react-datepicker__header {
   background-color: white;
   border-bottom: none;
 }
 
+/* 현재 월 */
 .react-datepicker__current-month {
   color: #a175ff;
   font-size: 16px;
 }
 
+/* 요일 라인 */
 .react-datepicker__day-names {
+  display: flex;
+  justify-content: space-around;
+  margin-left: 6px;
+  margin-right: 6px;
   margin-top: 20px;
 }
 
+/* 요일 */
 .react-datepicker__day-name {
   color: #a175ff;
   width: 32px;
@@ -114,21 +125,25 @@
   font-size: 14px;
 }
 
+/* 전체 달 */
 .react-datepicker__month {
-  padding: 8px;
+  display: flex;
+  flex-direction: column;
   background-color: white;
 }
 
+/* 주 */
 .react-datepicker__week {
   display: flex;
   justify-content: space-around;
 }
 
+/* 일 */
 .react-datepicker__day {
   width: 32px;
   height: 32px;
-  line-height: 32px;
   border-radius: 20px;
+  line-height: 32px;
   transition: all 0.2s ease;
   cursor: pointer;
   font-size: 14px;
@@ -246,12 +261,44 @@
     -webkit-touch-callout: none !important;
     -webkit-tap-highlight-color: transparent !important;
   }
+  /* 모바일일 경우 대략 가운데 위치 */
   .react-datepicker-popper {
     position: fixed !important;
     top: 45% !important;
-    left: 50% !important;
+    left: 53% !important;
     transform: translate(-50%, -50%) !important;
     z-index: 9999 !important;
     width: auto !important;
+  }
+
+  .react-datepicker {
+    width: 80vw !important;
+    max-width: 320px !important; /* 최대 너비 제한 */
+    min-width: 280px !important; /* 최소 너비 보장 */
+  }
+
+  /* 요일 라인 */
+  .react-datepicker__day-names {
+    display: flex;
+    justify-content: space-around;
+    margin-left: 6px;
+    margin-right: 6px;
+    margin-top: 20px;
+  }
+
+  /* 요일 */
+  .react-datepicker__day-name {
+    color: #a175ff;
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+    font-size: 14px;
+  }
+
+  /* 전체 달 */
+  .react-datepicker__month {
+    display: flex;
+    flex-direction: column;
+    background-color: white;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -253,14 +253,6 @@
 }
 
 @media (max-width: 500px) {
-  /* 모바일에서 키보드 입력 방지 */
-  .react-datepicker__input-container input {
-    caret-color: transparent !important;
-    user-select: none !important;
-    -webkit-user-select: none !important;
-    -webkit-touch-callout: none !important;
-    -webkit-tap-highlight-color: transparent !important;
-  }
   /* 모바일일 경우 대략 가운데 위치 */
   .react-datepicker-popper {
     position: absolute !important;

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -63,8 +63,19 @@ export default function MyHistoryPage() {
     const fetchHistory = async () => {
       setLoading(true);
       try {
-        const startParam = startDate ? startDate.toISOString().split('T')[0] : undefined;
-        const endParam = endDate ? endDate.toISOString().split('T')[0] : undefined;
+        let startParam: string | undefined;
+        let endParam: string | undefined;
+
+        if (startDate) {
+          startParam = dayjs(startDate).format('YYYY-MM-DD');
+          console.log('✅ startParam:', startParam);
+        }
+
+        if (endDate) {
+          endParam = dayjs(endDate).format('YYYY-MM-DD');
+          console.log('📝 종료 날짜:', dayjs(endDate).format('YYYY-MM-DD'));
+        }
+        console.log('시간 포함 날짜 파라미터:', { startParam, endParam });
         const res = await api.get('/api/v1/membership-history', {
           params: {
             keyword: keyword || undefined,
@@ -77,6 +88,7 @@ export default function MyHistoryPage() {
 
         const data = res.data?.data;
         if (data && Array.isArray(data.content)) {
+          console.log('멤버십 이력 데이터', data);
           setHistory(data.content);
           setCurrentPage(data.currentPage ?? 0);
           setTotalElements(data.totalElements ?? 0);
@@ -161,7 +173,10 @@ export default function MyHistoryPage() {
                   locale={ko}
                   showPopperArrow={false}
                   selected={startDate}
-                  onChange={(date) => setStartDate(date)}
+                  onChange={(date) => {
+                    console.log('📅 시작 날짜 선택됨:', date);
+                    setStartDate(date);
+                  }}
                   dateFormat="yyyy-MM-dd"
                   maxDate={endDate ?? undefined}
                   placeholderText="시작 날짜"
@@ -172,7 +187,10 @@ export default function MyHistoryPage() {
                   locale={ko}
                   showPopperArrow={false}
                   selected={endDate}
-                  onChange={(date) => setEndDate(date)}
+                  onChange={(date) => {
+                    console.log('📅 종료 날짜 선택됨:', date);
+                    setEndDate(date);
+                  }}
                   dateFormat="yyyy-MM-dd"
                   minDate={startDate ?? undefined}
                   placeholderText="종료 날짜"

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -273,7 +273,10 @@ export default function MyHistoryPage() {
                               {item.discountAmount.toLocaleString()}원
                             </span>
                             <span className="text-grey05 text-body-1 px-4 font-light max-xl:text-body-3 max-xl:font-light max-xl:px-3 max-xlg:text-body-5 max-lg:text-body-4">
-                              {dayjs(item.usedAt).format('YYYY-MM-DD HH:mm:ss')}
+                              {dayjs
+                                .utc(item.usedAt)
+                                .tz('Asia/Seoul')
+                                .format('YYYY-MM-DD HH:mm:ss')}
                             </span>
                           </div>
                         </div>

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -159,7 +159,7 @@ export default function MyHistoryPage() {
                   onChange={(date) => setStartDate(date)}
                   dateFormat="yyyy-MM-dd"
                   placeholderText="시작 날짜"
-                  className="border border-grey03 rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[90px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
+                  className="border border-grey03 text-center rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[110px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
                 />
                 <span className="text-grey05">~</span>
                 <DatePicker
@@ -167,7 +167,7 @@ export default function MyHistoryPage() {
                   onChange={(date) => setEndDate(date)}
                   dateFormat="yyyy-MM-dd"
                   placeholderText="종료 날짜"
-                  className="border border-grey03 rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[90px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
+                  className="border border-grey03 text-center rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[110px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
                 />
               </div>
             </div>

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -158,6 +158,7 @@ export default function MyHistoryPage() {
                   selected={startDate}
                   onChange={(date) => setStartDate(date)}
                   dateFormat="yyyy-MM-dd"
+                  maxDate={endDate ?? undefined}
                   placeholderText="시작 날짜"
                   className="border border-grey03 text-center rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[110px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
                 />
@@ -166,6 +167,7 @@ export default function MyHistoryPage() {
                   selected={endDate}
                   onChange={(date) => setEndDate(date)}
                   dateFormat="yyyy-MM-dd"
+                  minDate={startDate ?? undefined}
                   placeholderText="종료 날짜"
                   className="border border-grey03 text-center rounded-[12px] px-2 h-[50px] w-[120px] max-xl:text-body-3 max-xl:h-[44px] max-xl:w-[110px] max-xlg:w-full max-md:h-[36px] max-md:rounded-[10px] placeholder:text-grey05 placeholder:font-normal placeholder:text-center outline-none focus:border-purple04"
                 />

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -63,8 +63,21 @@ export default function MyHistoryPage() {
     const fetchHistory = async () => {
       setLoading(true);
       try {
-        const startParam = startDate ? startDate.toISOString().split('T')[0] : undefined;
-        const endParam = endDate ? endDate.toISOString().split('T')[0] : undefined;
+        let startParam: string | undefined;
+        let endParam: string | undefined;
+
+        if (startDate) {
+          // 날짜만 전송 (시간 제거)
+          startParam = dayjs(startDate).format('YYYY-MM-DD');
+          console.log('✅ startParam:', startParam);
+        }
+
+        if (endDate) {
+          // 종료 날짜는 하루 추가해서 전송 (포함되도록)
+          endParam = dayjs(endDate).format('YYYY-MM-DD');
+          console.log('📝 종료 날짜:', dayjs(endDate).format('YYYY-MM-DD'));
+        }
+        console.log('시간 포함 날짜 파라미터:', { startParam, endParam });
         const res = await api.get('/api/v1/membership-history', {
           params: {
             keyword: keyword || undefined,
@@ -77,6 +90,7 @@ export default function MyHistoryPage() {
 
         const data = res.data?.data;
         if (data && Array.isArray(data.content)) {
+          console.log('멤버십 이력 데이터', data);
           setHistory(data.content);
           setCurrentPage(data.currentPage ?? 0);
           setTotalElements(data.totalElements ?? 0);
@@ -161,7 +175,10 @@ export default function MyHistoryPage() {
                   locale={ko}
                   showPopperArrow={false}
                   selected={startDate}
-                  onChange={(date) => setStartDate(date)}
+                  onChange={(date) => {
+                    console.log('📅 시작 날짜 선택됨:', date);
+                    setStartDate(date);
+                  }}
                   dateFormat="yyyy-MM-dd"
                   maxDate={endDate ?? undefined}
                   placeholderText="시작 날짜"
@@ -172,7 +189,10 @@ export default function MyHistoryPage() {
                   locale={ko}
                   showPopperArrow={false}
                   selected={endDate}
-                  onChange={(date) => setEndDate(date)}
+                  onChange={(date) => {
+                    console.log('📅 종료 날짜 선택됨:', date);
+                    setEndDate(date);
+                  }}
                   dateFormat="yyyy-MM-dd"
                   minDate={startDate ?? undefined}
                   placeholderText="종료 날짜"
@@ -255,10 +275,7 @@ export default function MyHistoryPage() {
                               {item.discountAmount.toLocaleString()}원
                             </span>
                             <span className="text-grey05 text-body-1 px-4 font-light max-xl:text-body-3 max-xl:font-light max-xl:px-3 max-xlg:text-body-5 max-lg:text-body-4">
-                              {dayjs
-                                .utc(item.usedAt)
-                                .tz('Asia/Seoul')
-                                .format('YYYY-MM-DD HH:mm:ss')}
+                              {dayjs(item.usedAt).format('YYYY-MM-DD HH:mm:ss')}
                             </span>
                           </div>
                         </div>

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -67,13 +67,19 @@ export default function MyHistoryPage() {
         let endParam: string | undefined;
 
         if (startDate) {
-          startParam = dayjs(startDate).format('YYYY-MM-DD');
-          // console.log('✅ startParam:', startParam);
+          startParam = dayjs(startDate)
+            .tz('Asia/Seoul')
+            .startOf('day')
+            .utc()
+            .format('YYYY-MM-DDTHH:mm:ss');
         }
 
         if (endDate) {
-          endParam = dayjs(endDate).format('YYYY-MM-DD');
-          // console.log('📝 종료 날짜:', dayjs(endDate).format('YYYY-MM-DD'));
+          endParam = dayjs(endDate)
+            .tz('Asia/Seoul')
+            .endOf('day')
+            .utc()
+            .format('YYYY-MM-DDTHH:mm:ss');
         }
         console.log('시간 포함 날짜 파라미터:', { startParam, endParam });
         const res = await api.get('/api/v1/membership-history', {

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -68,12 +68,12 @@ export default function MyHistoryPage() {
 
         if (startDate) {
           startParam = dayjs(startDate).format('YYYY-MM-DD');
-          console.log('✅ startParam:', startParam);
+          // console.log('✅ startParam:', startParam);
         }
 
         if (endDate) {
           endParam = dayjs(endDate).format('YYYY-MM-DD');
-          console.log('📝 종료 날짜:', dayjs(endDate).format('YYYY-MM-DD'));
+          // console.log('📝 종료 날짜:', dayjs(endDate).format('YYYY-MM-DD'));
         }
         console.log('시간 포함 날짜 파라미터:', { startParam, endParam });
         const res = await api.get('/api/v1/membership-history', {

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -62,11 +62,13 @@ export default function MyHistoryPage() {
     const fetchHistory = async () => {
       setLoading(true);
       try {
+        const startParam = startDate ? startDate.toISOString().split('T')[0] : undefined;
+        const endParam = endDate ? endDate.toISOString().split('T')[0] : undefined;
         const res = await api.get('/api/v1/membership-history', {
           params: {
             keyword: keyword || undefined,
-            startDate: startDate ? dayjs(startDate).format('YYYY-MM-DD') : undefined,
-            endDate: endDate ? dayjs(endDate).format('YYYY-MM-DD') : undefined,
+            startDate: startParam,
+            endDate: endParam,
             page,
             size,
           },

--- a/src/pages/myPage/MyHistoryPage.tsx
+++ b/src/pages/myPage/MyHistoryPage.tsx
@@ -15,6 +15,7 @@ import SearchBar from '../../components/SearchBar';
 import NoResult from '../../components/NoResult';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
+import { ko } from 'date-fns/locale/ko';
 import { RiResetRightFill } from 'react-icons/ri';
 import FadeWrapper from '../../features/myPage/components/FadeWrapper';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -157,6 +158,8 @@ export default function MyHistoryPage() {
                   <RiResetRightFill />
                 </button>
                 <DatePicker
+                  locale={ko}
+                  showPopperArrow={false}
                   selected={startDate}
                   onChange={(date) => setStartDate(date)}
                   dateFormat="yyyy-MM-dd"
@@ -166,6 +169,8 @@ export default function MyHistoryPage() {
                 />
                 <span className="text-grey05">~</span>
                 <DatePicker
+                  locale={ko}
+                  showPopperArrow={false}
                   selected={endDate}
                   onChange={(date) => setEndDate(date)}
                   dateFormat="yyyy-MM-dd"


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 마이페이지 사용 내역 시차 이슈를 해결하였습니다.
2. 날짜 필터에서 시작 날짜 시 종료 날짜 이후는 선택하지 못하게, 종료 날짜 시 시작 날짜 이전은 선택할 수 없도록 하였습니다.
3. 달력을 커스텀하였고 모바일일 경우 달력은 가운데에 배치되게 하였습니다.
4. 날짜 필터 시 시차 이슈는 아직 해결하지 못했습니다.. 백에서 현재 날짜만 받고 있는데 시간도 받아야 해결이 될 것 같아요

## 스크린샷
<img width="406" height="470" alt="image" src="https://github.com/user-attachments/assets/f835d7af-53fc-4ee1-9c6b-d5c5af093c84" />
<img width="309" height="674" alt="image" src="https://github.com/user-attachments/assets/149b54bc-c34c-4e76-afec-404a982f14e5" />


## ✅ 작성자 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트)
- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
